### PR TITLE
Closes #CARNEGIE-138. Creates stub page and route for CARNEGIE-137

### DIFF
--- a/app/views/carnegie/_secondary_nav.html.erb
+++ b/app/views/carnegie/_secondary_nav.html.erb
@@ -11,6 +11,9 @@
 						<li><a href="<%=carnegie_about_path()%>#about_the_corporation">About the Corporation</a></li>
 					</ul>
   			</li>
+				<li>
+					<a href="<%=carnegie_centennial_exhibition_path()%>">Centennial Exhibition</a>
+				</li>
 				<li class="dropdown">
 					<a href="#" class="dropdown-toggle" data-toggle="dropdown"><span class="hidden-xs">Related </span>Resources <b class="caret"></b></a>
 					<ul class="dropdown-menu list-unstyled dropdown-menu-left">

--- a/app/views/carnegie/centennial_exhibition.html.erb
+++ b/app/views/carnegie/centennial_exhibition.html.erb
@@ -1,0 +1,9 @@
+<div class="col-md-8 col-md-offset-2">
+
+	<section class="ff" id="about_the_project">
+	<h2 class="h4">Centennial Exhibition</h2>
+		<p>
+The Carnegie Corporation of New York celebrated its centennial in 2011. From October 2011 through February 2012, the Columbia University Libraries and the Rare Book & Manuscript Library presented an exhibition highlighting the Corporation's extensive records and documenting its role in the history of philanthropy. The exhibition drew on the archives of four philanthropic institutions founded by Andrew Carnegie&mdash;the Carnegie Corporation of New York, Carnegie Endowment for International Peace, Carnegie Foundation for the Advancement of Teaching, and the Carnegie Council for Ethics in International Affairs—and illustrated how he used philanthropy to pursue his twin passions: the love of learning and the quest for world peace.
+		</p>
+	</section>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Dcv::Application.routes.draw do
   # Carnegie subsite routes
   get 'carnegie/about' => 'carnegie#about', as: :carnegie_about
   get 'carnegie/faq' => 'carnegie#faq', as: :carnegie_faq
+  get 'carnegie/centennial_exhibition' => 'carnegie#centennial_exhibition', as: :carnegie_centennial_exhibition
   get 'carnegie/map_search' => 'carnegie#map_search', as: :carnegie_map_search
 
   # Durst subsite routes


### PR DESCRIPTION
this Closes CARNEGIE-138 and sets up the initial page, and route for the new Centennial Exhibition static page with the provided blurb for CARNEGIE-137