### PR TITLE
use caption url when present to write track element for media js (DLC-696, DLC-699)

### DIFF
--- a/app/helpers/dcv/media_element_helper.rb
+++ b/app/helpers/dcv/media_element_helper.rb
@@ -1,43 +1,62 @@
 module Dcv::MediaElementHelper
-  def render_media_element_streaming_video_player(wowza_project, video_path, poster_path, width=1024, height=576)
+  def render_media_element_streaming_video_player(wowza_project, video_path, poster_path, captions_path = nil, width=1024, height=576)
+    if captions_path
+      # important not to mark up as default, or browser and mediaelement will both display
+      track_element = '<track label="English" kind="subtitles" srclang="en" src="' + captions_path + '" />'
+    end
     return ('<div class="mejs-ted"><div class="mediaelement-player">
       <video width="' + width.to_s + '" height="' + height.to_s + '" style="width:100%;height:100%;" poster="' + poster_path + '" controls="controls" preload="none">
-        <source type="application/dash+xml" src="https://firehose.cul.columbia.edu:8443/' + wowza_project + '/_definst_/mp4:' + video_path + '/manifest.mpd" />
         <source type="application/x-mpegURL" src="https://firehose.cul.columbia.edu:8443/' + wowza_project + '/_definst_/mp4:' + video_path + '/playlist.m3u8" />
         <source type="video/rtmp" src="rtmps://firehose.cul.columbia.edu:8443/' + wowza_project + '/_definst_/mp4:' + video_path + '" />
+        ' + track_element.to_s + '
       </video>
     </div></div>').html_safe
   end
 
-  def render_media_element_streaming_audio_player(url, poster_path, width=1024, height=576)
-    # TODO: Change this to audio element instead of video
+  def render_media_element_streaming_audio_player(url, poster_path, captions_path = nil, width=1024, height=576)
+    if captions_path
+      # important not to mark up as default, or browser and mediaelement will both display
+      track_element = '<track label="English" kind="subtitles" srclang="en" src="' + captions_path + '" />'
+    end
     return ('<div class="mejs-ted"><div class="mediaelement-player">
       <audio width="' + width.to_s + '" style="width:100%;" controls="controls" preload="none">
-        <source type="application/x-mpegURL" src="' + url + '" />
+        <source type="application/x-mpegURL" src="' + url + '" />' + track_element.to_s + '
       </audio>
     </div></div>').html_safe
   end
 
-  def render_media_element_streaming_player(url, poster_path, width=1024, height=576)
+  def render_media_element_streaming_player(url, poster_path, captions_path = nil, width=1024, height=576)
+    if captions_path
+      # important not to mark up as default, or browser and mediaelement will both display
+      track_element = '<track label="English" kind="subtitles" srclang="en" src="' + captions_path + '" />'
+    end
     return ('<div class="mejs-ted"><div class="mediaelement-player">
       <video width="' + width.to_s + '" height="' + height.to_s + '" style="width:100%;height:100%;" poster="' + poster_path + '" controls="controls" preload="none">
-        <source type="application/x-mpegURL" src="' + url + '" />
+        <source type="application/x-mpegURL" src="' + url + '" />' + track_element.to_s + '
       </video>
     </div></div>').html_safe
   end
 
-  def render_media_element_progressive_download_video_player(video_url, poster_path, width=1024, height=576)
+  def render_media_element_progressive_download_video_player(video_url, poster_path, captions_path = nil, width=1024, height=576)
+    if captions_path
+      # important not to mark up as default, or browser and mediaelement will both display
+      track_element = '<track label="English" kind="subtitles" srclang="en" src="' + captions_path + '" />'
+    end
     return ('<div class="mejs-ted"><div class="mediaelement-player">
       <video width="' + width.to_s + '" height="' + height.to_s + '" style="width:100%;height:100%;" poster="' + poster_path + '" controls="controls" preload="none">
-          <source type="video/mp4" src="' + video_url + '" />
+          <source type="video/mp4" src="' + video_url + '" />' + track_element.to_s + '
       </video>
     </div></div>').html_safe
   end
 
-  def render_media_element_progressive_download_audio_player(audio_url)
+  def render_media_element_progressive_download_audio_player(audio_url, captions_path = nil)
+    if captions_path
+      # important not to mark up as default, or browser and mediaelement will both display
+      track_element = '<track label="English" kind="subtitles" srclang="en" src="' + captions_path + '" />'
+    end
     return (
       '<audio class="mediaelement-player" style="width:100%;" controls="controls" preload="none">
-          <source type="audio/mp3" src="' + audio_url + '" />
+          <source type="audio/mp3" src="' + audio_url + '" />' + track_element.to_s + '
       </audio>'
     ).html_safe
   end

--- a/app/views/catalog/_show_generic_resource.html.erb
+++ b/app/views/catalog/_show_generic_resource.html.erb
@@ -46,7 +46,7 @@
           <div class="inner">
               <div id="generic-resource-video">
                 <div class="mediaelement-wrapper">
-                <%= render :partial=>"catalog/generic_resource/#{document['dc_type_ssm'].first.downcase}", :locals=> {wowza_project: 'vod', media_path: document['service_dslocation_ss'].gsub('file:/ifs/cul/ldpd/', ''), poster_path: poster_path, width: 1024, height: 576} %>
+                <%= render :partial=>"catalog/generic_resource/#{document['dc_type_ssm'].first.downcase}", :locals=> {wowza_project: 'vod', media_path: document['service_dslocation_ss'].gsub('file:/ifs/cul/ldpd/', ''), poster_path: poster_path, width: 1024, height: 576, document: document} %>
                 </div>
               </div>
           </div>

--- a/app/views/catalog/content_aggregator/child_viewer/_moving_image.html.erb
+++ b/app/views/catalog/content_aggregator/child_viewer/_moving_image.html.erb
@@ -1,15 +1,16 @@
 <%
 poster_url = get_resolved_asset_url(id: child[:id], size: 768, type: 'full', format: 'jpg')
-if DCV_CONFIG.fetch('media_streaming', {})['wowza'].present?
-  media_url = wowza_media_token_url(child)
-  player_src = render_media_element_streaming_player(media_url, poster_url, 1024, 500)
-else
-  media_url = bytestream_content_path(catalog_id: child[:pid], bytestream_id: 'access')
-  player_src = render_media_element_progressive_download_video_player(media_url, poster_url, 1024, 500)
-end
 dsa = child.fetch(:datastreams_ssim, [])
 has_chapters = dsa.include?('chapters')
 has_captions = dsa.include?('captions')
+captions_url = bytestream_content_path(catalog_id: child[:id], bytestream_id: 'captions') if has_captions
+if DCV_CONFIG.fetch('media_streaming', {})['wowza'].present?
+  media_url = wowza_media_token_url(child)
+  player_src = render_media_element_streaming_player(media_url, poster_url, captions_url, 1024, 500)
+else
+  media_url = bytestream_content_path(catalog_id: child[:pid], bytestream_id: 'access')
+  player_src = render_media_element_progressive_download_video_player(media_url, poster_url, captions_url, 1024, 500)
+end
 %>
 
 <div>

--- a/app/views/catalog/content_aggregator/child_viewer/_sound.html.erb
+++ b/app/views/catalog/content_aggregator/child_viewer/_sound.html.erb
@@ -1,15 +1,16 @@
 <%
 poster_url = Dcv::Utils::CdnUtils.random_cdn_url + '/iiif/2/cul:2rbnzs7hj2/full/!512,512/0/native.jpg'
-if DCV_CONFIG.fetch('media_streaming', {})['wowza'].present?
-  media_url = wowza_media_token_url(child)
-  player_src = render_media_element_streaming_audio_player(media_url, nil, 1024, 500)
-else
-  media_url = bytestream_content_path(catalog_id: child[:pid], bytestream_id: 'access')
-  player_src = render_media_element_progressive_download_audio_player(media_url)
-end
 dsa = child.fetch(:datastreams_ssim, [])
 has_chapters = dsa.include?('chapters')
 has_captions = dsa.include?('captions')
+captions_url = bytestream_content_path(catalog_id: child[:id], bytestream_id: 'captions') if has_captions
+if DCV_CONFIG.fetch('media_streaming', {})['wowza'].present?
+  media_url = wowza_media_token_url(child)
+  player_src = render_media_element_streaming_audio_player(media_url, nil, captions_url, 1024, 500)
+else
+  media_url = bytestream_content_path(catalog_id: child[:pid], bytestream_id: 'access')
+  player_src = render_media_element_progressive_download_audio_player(media_url, captions_url)
+end
 %>
 
 <div>

--- a/app/views/catalog/generic_resource/_video.html.erb
+++ b/app/views/catalog/generic_resource/_video.html.erb
@@ -1,1 +1,8 @@
-<%= render_media_element_streaming_video_player(wowza_project, media_path, poster_path) %>
+<%
+document ||= {} # in case legacy code is not passing
+dsa = document.fetch(:datastreams_ssim, [])
+has_chapters = dsa.include?('chapters')
+has_captions = dsa.include?('captions')
+captions_url = bytestream_content_path(catalog_id: document[:id], bytestream_id: 'captions') if has_captions
+%>
+<%= render_media_element_streaming_video_player(wowza_project, media_path, poster_path, captions_url) %>


### PR DESCRIPTION
remove dash source element from mediaelement widget ouput to prevent js error