### PR TITLE
Dlc 677 reading room pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'active-fedora', '>= 7.3.1'
 gem 'rubydora', :git => 'https://github.com/elohanlon/rubydora', branch: 'datastream_dissemination_with_headers'
 
 # Columbia Hydra models
-gem 'cul_hydra', '~> 1.7.6'
+gem 'cul_hydra', '~> 1.8.0'
 #gem 'cul_hydra', :path => '../cul_hydra'
 gem 'cul_omniauth', '~>0.5.2'
 gem 'active-triples', '~> 0.2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ GEM
       rails (>= 3.1.1)
     concurrent-ruby (1.0.5)
     crass (1.0.4)
-    cul_hydra (1.7.6)
+    cul_hydra (1.8.0)
       active-fedora (>= 7.3.1)
       active-triples (~> 0.2.2)
       active_fedora_finders (>= 0.5.0)
@@ -166,6 +166,7 @@ GEM
       rdf (>= 1.1.5)
       rubydora (~> 2.0.0)
       sparql
+      sprockets (~> 3.0)
       thread
     cul_image_props (0.3.6)
       nokogiri
@@ -192,8 +193,8 @@ GEM
     ebnf (0.3.9)
       rdf (~> 1.1)
       sxp (~> 0.1, >= 0.1.3)
-    edtf (3.0.4)
-      activesupport (>= 3.0, < 6.0)
+    edtf (3.0.5)
+      activesupport (>= 3.0, < 7.0)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     erubis (2.7.0)
@@ -234,7 +235,7 @@ GEM
       rails (>= 3.2.6)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    iso-639 (0.2.8)
+    iso-639 (0.3.3)
     jbuilder (1.5.3)
       activesupport (>= 3.0.0)
       multi_json (>= 1.2.0)
@@ -558,7 +559,7 @@ DEPENDENCIES
   coderay
   coffee-rails (~> 4.0.0)
   colorbox-rails
-  cul_hydra (~> 1.7.6)
+  cul_hydra (~> 1.8.0)
   cul_omniauth (~> 0.5.2)
   devise (~> 3.4)
   devise-guests (~> 0.3)

--- a/app/assets/stylesheets/dcv/dcv.css.scss
+++ b/app/assets/stylesheets/dcv/dcv.css.scss
@@ -244,6 +244,27 @@ input {
 			}
 		}
 	}
+	h2 {
+		width: 100%;
+		padding: 2px 0 0;
+		margin-bottom: .5em;
+		text-align: center;
+		font-family: $font_0, $font_1, $font_4, $font_2;
+		font-size: 180%;
+		a {
+			color: $color_9;
+			&:hover {
+				text-decoration: none;
+			}
+			img {
+				max-width: 100%;
+			}
+		}
+	}
+	.note {
+		text-align: center;
+		max-width: 100%;
+	}
 	#site-banner-inner .col-sm-3 > a {
 		display: inline-block;
 		max-width: 100%;
@@ -300,6 +321,13 @@ input {
 			margin-bottom: .5em;
 			padding-top: 1em;
 			border-top: 1px solid $color_28;
+			&.compact {
+			  min-height: auto;
+				&:first-child {
+					padding-top: 1em;
+					border-top: 0;
+				}
+			}
 			&:first-child {
 				padding-top: 0;
 				border-top: 0;
@@ -588,6 +616,29 @@ h2[itemprop="name"] {
 }
 #sidebar {
 	clear: both;
+	.panel-default {
+		border-color: $color_18;
+		border-style: solid;
+	}
+	.panel-body .nav {
+		a {
+			@extend %extend_1;
+			&:hover {
+				color: $color_9;
+			}
+		}
+		.btn-link {
+			@extend %extend_1;
+			&:hover {
+				color: $color_9;
+			}
+		}
+	}
+	.panel-title:hover {
+		text-decoration: none;
+	}
+}
+#sidebar-right {
 	.panel-default {
 		border-color: $color_18;
 		border-style: solid;

--- a/app/assets/stylesheets/dcv/dcv.css.scss
+++ b/app/assets/stylesheets/dcv/dcv.css.scss
@@ -357,6 +357,23 @@ input {
 			}
 		}
 	}
+	h2.banner {
+		width: 100%;
+		padding: 2px 0 0;
+		margin-bottom: .5em;
+		text-align: center;
+		font-family: $font_1, $font_4, $font_2, $font_0;
+		font-size: 180%;
+		a {
+			color: $color_9;
+			&:hover {
+				text-decoration: none;
+			}
+			img {
+				max-width: 100%;
+			}
+		}
+	}
 	.col-sm-2 .thumbnail {
 		height: 100px;
 		text-align: center;

--- a/app/controllers/repositories/catalog_controller.rb
+++ b/app/controllers/repositories/catalog_controller.rb
@@ -1,0 +1,82 @@
+module Repositories
+  class CatalogController < ::SubsitesController
+    include Dcv::MapDataController
+
+    before_action :set_map_data_json, only: [:map_search]
+    #before_action :set_map_data_json, only: [:index, :map_search]
+
+    configure_blacklight do |config|
+      Dcv::Configurators::DcvBlacklightConfigurator.configure(config)
+      config.show.route = { controller: :current }
+    end
+
+    def initialize(*args)
+      super(*args)
+      self._prefixes.unshift 'repositories'
+      self._prefixes.unshift 'repositories/catalog'
+    end
+
+    def set_view_path
+      super
+      self.prepend_view_path('app/views/repositories')
+      self.prepend_view_path('app/views/repositories/catalog')
+    end
+
+    def solr_search_params(user_params = {})
+      super.tap do |solr_params|
+        if params[:repository_id] == 'NNC-RB'
+          fq = 'lib_repo_code_ssim:("' + ['NNC-RB', 'NyNyCOH', 'NNC-UA'].join('" OR "') + '")'
+        else
+          fq = "lib_repo_code_ssim:\"#{params[:repository_id]}\""
+        end
+        solr_params[:fq] << fq
+      end
+    end
+
+    # SubsiteController Overrides
+    def self.subsite_config
+      {}
+    end
+
+    def subsite_config
+      return self.class.subsite_config
+    end
+
+    def default_search_mode
+      subsite_config.fetch('default_search_mode',:grid)
+    end
+
+    def default_search_mode_cookie
+      cookie_name = "#{params[:repository_id]}_search_mode".to_sym
+      cookie = cookies[cookie_name]
+      unless cookie
+        cookies[cookie_name] = default_search_mode.to_sym
+      end
+    end
+
+    def subsite_key
+      key = params[:repository_id].dup
+      key.downcase!
+      key.gsub!('-','')
+      key
+    end
+
+    def subsite_layout
+      'dcv'
+    end
+
+    def index
+      if request.format.csv?
+        stream_csv_response_for_search_results
+      else
+        super
+      end
+    end
+
+    def about
+    end
+
+    def aboutcollection
+    end
+  end
+end

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -67,8 +67,9 @@ class RepositoriesController < ApplicationController
       }
       t[:facet_value] = solr_doc.fetch('short_title_ssim',[]).first if published_to_catalogs?(solr_doc)
       t[:facet_field] = (t[:search_scope] == 'collection') ? 'lib_collection_sim' : 'lib_project_short_ssim'
-      # TODO: find a way to limit to reading room scope; maybe wildcard reading room listing?
-      # t[:in_scope] = solr_doc.fetch('publisher_ssim',[]).include?(site_uri(restricted))
+      unless t[:external_url]
+        t[:external_url] = solr_doc[:restriction_ssim].present? ? restricted_site_url(solr_doc.fetch('slug_ssim',[]).first) : site_url(solr_doc.fetch('slug_ssim',[]).first)
+      end
       t
     end
   end

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -1,0 +1,124 @@
+require 'redcarpet'
+
+class RepositoriesController < ApplicationController
+  include Dcv::CatalogIncludes
+  include Dcv::CdnHelper
+
+  layout Proc.new { |controller| 'dcv' }
+
+  configure_blacklight do |config|
+    config.default_solr_params = {
+      :fq => [
+        'object_state_ssi:A', # Active items only
+        'active_fedora_model_ssi:Concept',
+        'dc_type_sim:"Publish Target"',
+        '-slug_ssim:sites', # Do not include sites publish targets in this list
+      ],
+      :sort => "title_si asc",
+      :qt => 'search'
+    }
+    config.add_search_field ActiveFedora::SolrService.solr_name('all_text', :searchable, type: :text) do |field|
+      field.label = 'All Fields'
+      field.default = true
+      field.solr_parameters = {
+        :qf => [ActiveFedora::SolrService.solr_name('all_text', :searchable, type: :text)],
+        :pf => [ActiveFedora::SolrService.solr_name('all_text', :searchable, type: :text)]
+      }
+    end
+  end
+
+  before_filter :set_repository_id, only:[:show]
+
+  def initialize(*args)
+    super(*args)
+    self._prefixes.unshift 'repositories'
+  end
+
+  def set_view_path
+    super
+    self.prepend_view_path('app/views/repositories')
+  end
+
+  def set_repository_id
+    params[:repository_id] = params[:id] # routing hack for sanity in the partials
+  end
+
+  ##
+  # If the current action should start a new search session, this should be
+  # set to true
+  # see also Blacklight::Catalog::SearchContext
+  def start_new_search_session?
+    true
+  end
+
+  def digital_projects(restricted = false)
+    fq = solr_search_params.fetch(:fq,[])
+    fq << "lib_repo_code_ssim:\"#{params[:repository_id]}\""
+    unless @document_list
+      (@response, @document_list) = get_search_results(params, {fq: fq})
+    end
+    @document_list.map do |solr_doc|
+      t = {
+        name: strip_restricted_title_qualifier(solr_doc.fetch('title_ssm',[]).first),
+        image: thumbnail_url(solr_doc),
+        external_url: solr_doc.fetch('source_ssim',[]).first || site_url(solr_doc.fetch('slug_ssim',[]).first),
+        description: solr_doc.fetch('abstract_ssim',[]).first,
+        search_scope: solr_doc.fetch('search_scope_ssi', "project") || "project"
+      }
+      t[:facet_value] = solr_doc.fetch('short_title_ssim',[]).first if published_to_catalogs?(solr_doc)
+      t[:facet_field] = (t[:search_scope] == 'collection') ? 'lib_collection_sim' : 'lib_project_short_ssim'
+      # TODO: find a way to limit to reading room scope; maybe wildcard reading room listing?
+      # t[:in_scope] = solr_doc.fetch('publisher_ssim',[]).include?(site_uri(restricted))
+      t
+    end
+  end
+
+  def strip_restricted_title_qualifier(qualified_title)
+    unqualified_title = qualified_title.dup
+    unqualified_title.sub!(/\s*[\[\(]Restricted[\)\]]\s*/i, '')
+    unqualified_title
+  end
+
+  def published_to_catalogs?(document={})
+    document && (document.fetch('publisher_ssim',[]) & catalog_uris).present?
+  end
+
+  def catalog_uris
+    ['restricted', 'public'].map { |top| SUBSITES[top].fetch('catalog',{})['uri'] }.compact
+  end
+
+  def site_uri(restricted = false)
+    top = restricted ? 'restricted' : 'public'
+    SUBSITES[top].fetch('sites',{})['uri']
+  end
+
+  def show
+    redirect_to repository_reading_room_path(repository_id: params[:id])
+  end
+
+  def reading_room
+    template_key = params[:repository_id].downcase
+    template_key.gsub!("-","")
+    render "reading_room/#{template_key}/show"
+  end
+
+  def reading_room_client?
+    (repository_ids_for_client & [params[:repository_id]]).present?
+  end
+
+  def repository_ids_for_client(remote_ip = request.remote_ip)
+    Rails.application.config_for(:location_uris).map do |location_uri, location|
+      if location.fetch('remote_ip', []).include?(remote_ip.to_s)
+        location.fetch('repository_id', nil)
+      end
+    end.compact
+  end
+
+  # Overrides the Blacklight::Controller provided #search_action_url.
+  # By default, any search action from a Blacklight::Catalog controller
+  # should use the current controller when constructing the route.
+  # see also HomeController
+  def search_action_url options = {}
+    url_for(options.merge(:action => 'index', :controller=>'catalog'))
+  end
+end

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -61,7 +61,7 @@ class RepositoriesController < ApplicationController
       t = {
         name: strip_restricted_title_qualifier(solr_doc.fetch('title_ssm',[]).first),
         image: thumbnail_url(solr_doc),
-        external_url: solr_doc.fetch('source_ssim',[]).first || site_url(solr_doc.fetch('slug_ssim',[]).first),
+        external_url: solr_doc.fetch('source_ssim',[]).first, # TODO: Handle landing page sites in this context
         description: solr_doc.fetch('abstract_ssim',[]).first,
         search_scope: solr_doc.fetch('search_scope_ssi', "project") || "project"
       }

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -146,9 +146,11 @@ class SitesController < ApplicationController
         name: solr_doc.fetch('title_ssm',[]).first,
         image: thumbnail_url(solr_doc),
         external_url: solr_doc.fetch('source_ssim',[]).first || site_url(solr_doc.fetch('slug_ssim',[]).first),
-        description: solr_doc.fetch('abstract_ssim',[]).first
+        description: solr_doc.fetch('abstract_ssim',[]).first,
+        search_scope: solr_doc.fetch('search_scope_ssi', "project") || "project"
       }
       t[:facet_value] = solr_doc.fetch('short_title_ssim',[]).first if published_to_catalog?(solr_doc)
+      t[:facet_field] = (t[:search_scope] == 'collection') ? 'lib_collection_sim' : 'lib_project_short_ssim'
       t
     end
   end

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -22,8 +22,6 @@ class SitesController < ApplicationController
       :qt => 'search'
     }
 
-    publisher = self.restricted? ? SUBSITES['restricted']['uri'] : SUBSITES['public']['uri']
-    config.default_solr_params[:fq] << "publisher_ssim:\"#{publisher}\""
     config.default_per_page = 250
     config.per_page = [20,60,100,250]
     config.max_per_page = 250
@@ -72,6 +70,13 @@ class SitesController < ApplicationController
         :qf => [ActiveFedora::SolrService.solr_name('lib_name', :searchable, type: :text)],
         :pf => [ActiveFedora::SolrService.solr_name('lib_name', :searchable, type: :text)]
       }
+    end
+  end
+
+  def solr_search_params(user_params = {})
+    super.tap do |solr_params|
+      fq = "publisher_ssim:\"#{self.restricted? ? SUBSITES['restricted']['uri'] : SUBSITES['public']['uri']}\""
+      solr_params[:fq] << fq
     end
   end
 

--- a/app/helpers/dcv/dcv_url_helper.rb
+++ b/app/helpers/dcv/dcv_url_helper.rb
@@ -121,6 +121,19 @@ module Dcv::DcvUrlHelper
     return url_for({controller: controller_name, action: 'index', search_field: 'all_text_teim', q: '', 'f' => {'durst_subjects_ssim' => [subject_term_value]}})
   end
 
+  def landing_page_search_url(document)
+    return nil unless document[:short_title_ssim].present?
+    search_scope = document.fetch('search_scope_ssi', "project") || "project"
+    facet_field = (search_scope == 'collection') ? 'lib_collection_sim' : 'lib_project_short_ssim'
+    facet_value = document.fetch('short_title_ssim',[]).first
+    if document[:restriction_ssim].present?
+      repository_id = document[:lib_repo_code_ssim].first
+      repository_catalog_index_path(repository_id: repository_id, f: {digital_project[:facet_field] => [digital_project[:facet_value]]})
+    else
+      search_action_path(:f => {facet_field => [facet_value]})
+    end
+  end
+
   def terms_of_use_url
     'https://library.columbia.edu/resolve/lweb0208'
   end

--- a/app/helpers/dcv/dcv_url_helper.rb
+++ b/app/helpers/dcv/dcv_url_helper.rb
@@ -128,7 +128,7 @@ module Dcv::DcvUrlHelper
     facet_value = document.fetch('short_title_ssim',[]).first
     if document[:restriction_ssim].present?
       repository_id = document[:lib_repo_code_ssim].first
-      repository_catalog_index_path(repository_id: repository_id, f: {digital_project[:facet_field] => [digital_project[:facet_value]]})
+      repository_catalog_index_path(repository_id: repository_id, f: {facet_field => [facet_value]})
     else
       search_action_path(:f => {facet_field => [facet_value]})
     end

--- a/app/views/catalog/_show_concept.html.erb
+++ b/app/views/catalog/_show_concept.html.erb
@@ -13,7 +13,7 @@
     <%= document['description_text_ssm'].blank? ? Array(document['abstract_ssim']).join : controller.render_markdown(Array(document['description_text_ssm']).join)  %>
     <div id="show-concept-links" class="index-show-list-fields">
       <ul>
-      <% dcv_search_link = document[:short_title_ssim].present? ? search_action_path(:f => {'lib_project_short_ssim' => [document[:short_title_ssim].first]}) : nil %>
+      <% dcv_search_link = landing_page_search_url(document) %>
       <% if dcv_search_link && controller.published_to_catalog?(document) %>
         <li>Browse: <%= link_to("#{document_show_html_title} content in the DLC".html_safe, dcv_search_link) %></li>
       <% end %>

--- a/app/views/home/restricted.html.erb
+++ b/app/views/home/restricted.html.erb
@@ -22,56 +22,28 @@
                 <div class="content">
                     <div class="" id="projects">
 
-          					  <div class="col-sm-6">
-            						<div class="row">
-            							<div class="col-sm-12">
-            							  <h4>Ford IFP Archive</h4>
-            								<p><a class="project-image-link" href="<%= restricted_ifp_index_path()  %>"><img src="<%= asset_url('ifp/IFP-square-logo.png'); %>" class="thumbnail img-responsive col-sm-5" alt="Ford IFP" style="margin-right:1em;"></a>
-            								The archives cover the issues of social justice, community development, and access to higher education, and include paper and digital documentation and audiovisual materials on the more than 4,300 IFP Fellows as well as comprehensive planning and administrative files of the program. <a style="display:block;" href="<%= restricted_ifp_index_path()  %>">View this content &raquo;</a></p>
-            							</div>
-            						</div>
-          					  </div>
-
-                      <hr class="visible-xs">
-
-                      <div class="col-sm-6">
-            						<div class="row">
-            							<div class="col-sm-12">
-            							  <h4>Thomas de Waal Interviews</h4>
-                            <% de_waal_search_link = restricted_catalog_index_path({search_field: 'all_text_teim', f: {lib_project_short_ssim: ['Thomas de Waal Interviews']}, q: ''}) %>
-            							  <p><a class="project-image-link" href="<%= de_waal_search_link %>"><img src="<%= asset_url('digital_projects_page/de_waal.jpg'); %>" class="thumbnail img-responsive col-sm-5" alt="University Seminars" style="margin-right:1em;"></a>
-            								Thomas de Waal conducted interviews with some sixty participants and policymakers during the struggle between former Soviet Republics Armenia and Azerbaijan over the disputed Nagorno-Karabakh region, and Russia’s conflict with the breakaway republic of Chechnya. These files are an important resource for scholars and journalists alike.<a style="display:block;" href="<%= de_waal_search_link %>">View this content &raquo;</a></p>
-            							</div>
-            						</div>
-            				  </div>
-
-                      <hr class="visible-xs">
-
-                      <div class="col-sm-6">
                         <div class="row">
-                          <div class="col-sm-12">
-                            <h4>University Seminars Digital Archive</h4>
-                            <p><a class="project-image-link" href="<%= restricted_universityseminars_index_path()  %>"><img src="<%= asset_url('digital_projects_page/usem.jpg'); %>" class="thumbnail img-responsive col-sm-5" alt="University Seminars" style="margin-right:1em;"></a>
-                            Founded in 1944 by Frank Tannenbaum, The University Seminars are groups of professors and experts from Columbia University and elsewhere. Seminars gather monthly to work together on problems that cross the boundaries between university departments. <a style="display:block;" href="<%= restricted_universityseminars_index_path() %>">View this content &raquo;</a></p>
-                          </div>
+                          <h2 class="banner"><%= link_to("Avery Architectural and Fine Arts Library Reading Room", repository_reading_room_path(repository_id: 'NNC-A')) %></h2>
                         </div>
-                      </div>
 
-                      <hr class="visible-xs">
+                        <div class="row">
+                          <h2 class="banner"><%= link_to("C.V. Starr East Asian Library Reading Room", repository_reading_room_path(repository_id: 'NNC-EA')) %></h2>
+                        </div>
 
-          					  <div class="col-sm-6">
-            						<div class="row">
-            							<div class="col-sm-12">
-            							  <h4>Time-Based Media</h4>
-            							  <p><a class="project-image-link" href="<%= restricted_time_based_media_index_path()  %>"><img src="<%= asset_url('digital_projects_page/tbm.png'); %>" class="thumbnail img-responsive col-sm-5" alt="Time-Based Media" style="margin-right:1em;"></a>
-            								This initiative focuses on at-risk unique audio and moving image content that CUL currently holds on analog media – specifically, enabling access to and preserving this content for teaching, learning, and research now and in the future.<a style="display:block;" href="<%= restricted_time_based_media_index_path() %>">View this content &raquo;</a></p>
-            							</div>
-            						</div>
-          					  </div>
+                        <div class="row">
+                          <h2 class="banner"><%= link_to("Rare Book & Manuscript Library Reading Room", repository_reading_room_path(repository_id: 'NNC-RB')) %></h2>
+                        </div>
 
+                        <div class="row">
+                          <h2 class="banner"><%= link_to("The Burke Library at Union Theological Seminary Reading Room", repository_reading_room_path(repository_id: 'NyNyCBL')) %></h2>
+                        </div>
+
+                        <div class="row">
+                          <h2 class="banner"><%= link_to("Music & Arts Library Reading Room", repository_reading_room_path(repository_id: 'NyNyCMA')) %></h2>
+                        </div>
                     </div>
                 </div>
-				<div class="clearfix"></div>
+        <div class="clearfix"></div>
             </div> <!--/.inner-->
         </div>
   </div>

--- a/app/views/layouts/dcv.html.erb
+++ b/app/views/layouts/dcv.html.erb
@@ -13,7 +13,7 @@
   <div id="outer-wrapper" class="container">
     <div class="row">
 
-	  <%= render partial: 'shared/header_navbar' %>
+	  <%= render partial: 'header_navbar' %>
 
 	  <%= render partial: 'shared/ajax_modal' %>
 

--- a/app/views/pages/projects_and_exhibitions.html.erb
+++ b/app/views/pages/projects_and_exhibitions.html.erb
@@ -12,7 +12,7 @@
 				<div class="col-sm-3">
 					<div class="row" itemscope itemtype="http://schema.org/CreativeWork">
 						<div class="col-sm-12">
-							<% dcv_search_link = digital_project[:facet_value].present? ? catalog_index_path(:f => {'lib_project_short_ssim' => [digital_project[:facet_value]]}) : nil %>
+							<% dcv_search_link = (digital_project[:facet_field].present? && digital_project[:facet_value].present?) ? catalog_index_path(:f => {digital_project[:facet_field] => [digital_project[:facet_value]]}) : nil -%>
 							<%= link_to image_tag(digital_project[:image], :class => 'thumbnail img-responsive', :itemprop => 'image', alt: digital_project[:name]), (dcv_search_link.present? ? dcv_search_link : digital_project[:external_url]), class: 'project-image-link' %>
 							<div>
 								<div class=" proj-jav btn-group btn-group-justified" role="group">

--- a/app/views/repositories/_archives_search_form.html.erb
+++ b/app/views/repositories/_archives_search_form.html.erb
@@ -1,0 +1,14 @@
+<%= form_tag 'https://archivesportal.library.columbia.edu/results.php', :method => :get, :class => 'clearfix' do %>
+  <div class="input-group">
+    <label for="archives_q" class="sr-only"><%= t('blacklight.search.form.q') %></label>
+    <%= text_field_tag :component_text, params[:component_text], :placeholder => (!query_has_constraints? ?  t(:"dlc.search_placeholder.new.#{controller.controller_name}", default: :'dlc.search_placeholder.new.default').html_safe : t(:"dlc.search_placeholder.modified.#{controller.controller_name}", default: :'dlc.search_placeholder.modifed.default').html_safe), :class => "search_q q form-control", :id => "archives_q" %>
+    <input type="hidden" name="repository_code" value="<%= params[:repository_id].downcase %>" />
+    <input type="hidden" name="level" value="collection" />
+    <div class="input-group-btn">
+      <button class="btn btn-primary search-btn" type="submit" aria-label="Submit">
+        <span class="glyphicon glyphicon-search"></span>
+      </button>
+    </div>
+  </div>
+
+<% end %>

--- a/app/views/repositories/_footer.html.erb
+++ b/app/views/repositories/_footer.html.erb
@@ -1,0 +1,5 @@
+<%
+template_key = params[:repository_id].downcase
+template_key.gsub!("-","")
+%>
+<%= render template: "reading_room/#{template_key}/footer", locals: {} %>

--- a/app/views/repositories/_header_navbar.html.erb
+++ b/app/views/repositories/_header_navbar.html.erb
@@ -1,0 +1,7 @@
+<%
+template_key = params[:repository_id].downcase
+template_key.gsub!("-","")
+%>
+<div class="container">
+<%= render template: "reading_room/#{template_key}/banner", locals: { repository_key: params[:repository_id] } %>
+</div>

--- a/app/views/repositories/_search_form.html.erb
+++ b/app/views/repositories/_search_form.html.erb
@@ -1,0 +1,23 @@
+<% search_action_url = repository_catalog_index_path(repository_id: params[:repository_id]) -%>
+<%= form_tag search_action_url, :method => :get, :class => 'clearfix' do %>
+  <%= render_hash_as_hidden_fields(params_for_search().except(:q, :search_field, :repository_id, :qt, :page, :utf8, :format)) %>
+
+  <div class="input-group">
+    <% unless search_fields.empty? %>
+    <span class="input-group-addon hide"> <%# to be removed. might need hidde %>
+      <label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>
+      <%= select_tag(:search_field, options_for_select(search_fields, h(params[:search_field])), :title => t('blacklight.search.form.search_field.title'), :class=>"search_field") %>
+      <span class="sr-only"><%= t('blacklight.search.form.search_field.post_label') %></span>
+    </span>
+    <% end %>
+    <label for="q" class="sr-only"><%= t('blacklight.search.form.q') %></label>
+    <%= text_field_tag :q, params[:q], :placeholder => (!query_has_constraints? ?  t(:"dlc.search_placeholder.new.#{controller.controller_name}", default: :'dlc.search_placeholder.new.default').html_safe : t(:"dlc.search_placeholder.modified.#{controller.controller_name}", default: :'dlc.search_placeholder.modifed.default').html_safe), :class => "search_q q form-control", :id => "q" %>
+    <div class="input-group-btn">
+  <%= link_to '<i class="glyphicon glyphicon-remove"></i>'.html_safe, start_over_path, :title => 'Start Over', :class => 'btn btn-default reset-btn' if query_has_constraints? %>
+      <button class="btn btn-primary search-btn" type="submit" aria-label="Submit">
+        <span class="glyphicon glyphicon-search"></span>
+      </button>
+    </div>
+  </div>
+
+<% end %>

--- a/app/views/repositories/reading_room/nnca/about.html.erb
+++ b/app/views/repositories/reading_room/nnca/about.html.erb
@@ -1,0 +1,7 @@
+<%
+div_id ||= "home-sidebar-news"
+%>
+<div id="<%= div_id %>">
+<p>A core objective of the Columbia University Libraries is to make our archival collections accessible for research and scholarship. However, certain digital items cannot be published online due to copyright restrictions or privacy and confidentiality concerns.</p>
+<p>Oral histories, recordings, videos, etc., can be found in many collections of Avery Drawings & Archives. These materials can only be viewed in the Avery Drawings & Archives reading room. <a href="https://library.columbia.edu/libraries/avery/da/consult.html">Please see this webpage on how to make an appointment</a>. Requests for obtaining copies of these materials are subject to approval by designated staff members.</p>
+</div>

--- a/app/views/repositories/reading_room/nnca/archives.html.erb
+++ b/app/views/repositories/reading_room/nnca/archives.html.erb
@@ -1,0 +1,5 @@
+<div class="row">
+	<h3>Archival Collections Portal</h3>
+	<p>View archival finding aids that include links to both open and restricted digital content.</p>
+	<%= render template: '_archives_search_form' %>
+</div>

--- a/app/views/repositories/reading_room/nnca/banner.html.erb
+++ b/app/views/repositories/reading_room/nnca/banner.html.erb
@@ -1,0 +1,28 @@
+<% if current_page?(repository_url(repository_key)) or current_page?(repository_reading_room_url(repository_id: repository_key)) %>
+<div id="site-banner" class="slim">
+	<div class="row">
+		<div id="site-banner-inner">
+			<h1>Columbia University Libraries Digital Collections</h1>
+			<h2>Avery Archictectural and Fine Arts Library</h2>
+		</div>
+		<% if controller.reading_room_client? -%>
+			<div class="note">This workstation provides access to content that can only be viewed on-site in the reading room.</div>
+		<% end -%>
+	</div>
+</div>
+<% else %>
+	<div id="site-banner" class="slim">
+		<div class="row">
+			<div id="site-banner-inner">
+				<div class="col-sm-3">
+					<a href="<%= repository_path(repository_key) %>">Avery Archictectural and Fine Arts Library</a>
+				</div>
+				<div class="col-sm-9">
+					<div id="search-navbar" class="navbar navbar-default slim" role="navigation">
+						<%= render template: '_search_form'  %>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+<% end %>

--- a/app/views/repositories/reading_room/nnca/footer.html.erb
+++ b/app/views/repositories/reading_room/nnca/footer.html.erb
@@ -1,0 +1,11 @@
+<footer class="container">
+	<hr />
+	<div class="row">
+		<div class="col-md-6">
+			<p><small>300 Avery Hall &bull; avery-drawings@columbia.edu</small></p>
+		</div>
+		<div class="col-md-6 text-right">
+			<p><small><%= link_to 'Copyright and Permissions', terms_of_use_url %> | <a href="#" onclick="return DCV.FeedbackModal.show();">Suggestions &amp; Feedback</a></small></p>
+		</div>
+	</div>
+</footer>

--- a/app/views/repositories/reading_room/nnca/highlights.html.erb
+++ b/app/views/repositories/reading_room/nnca/highlights.html.erb
@@ -1,0 +1,4 @@
+<h4>Avery Drawings &amp; Archives Collections</h4>
+<p><a href="https://library.columbia.edu/libraries/avery/da/collections.html">Avery Drawings & Archives collections list</a></p>
+<hr>
+<p><a href="https://library.columbia.edu/libraries/avery/da/consult.html">Avery Drawings &amp; Archives Research and appointments</a></p>

--- a/app/views/repositories/reading_room/nnca/show.html.erb
+++ b/app/views/repositories/reading_room/nnca/show.html.erb
@@ -1,0 +1,20 @@
+<%
+template_key = params[:repository_id].downcase
+template_key.gsub!("-","")
+%>
+<div class="container">
+  <div id="sidebar" class="col-md-3">
+    <div class="inner">
+      <%= render template: "reading_room/#{template_key}/about", locals: {div_id: "home-sidebar-news"} %>
+    </div>
+  </div>
+  <div id="portals" class="col-md-6">
+    <%= render template: "reading_room/#{template_key}/archives" %>
+    <%= render template: 'reading_room/projects_and_exhibitions' %>
+  </div>
+  <div id="sidebar-right" class="col-md-3">
+    <div class="inner">
+      <%= render template: "reading_room/#{template_key}/highlights", locals: {div_id: "home-sidebar-highlights"} %>
+    </div>
+  </div>
+</div>

--- a/app/views/repositories/reading_room/nncea/about.html.erb
+++ b/app/views/repositories/reading_room/nncea/about.html.erb
@@ -1,0 +1,9 @@
+<%
+div_id ||= "home-sidebar-news"
+%>
+<div id="<%= div_id %>">
+<p>A core objective of Columbia University Libraries C.V. Starr East Asian Library is to make our archival collections accessible for research and
+scholarship. However, certain digital items cannot be published online due to copyright restrictions or privacy and confidentiality concerns.</p>
+<p>These materials can only be viewed in the Starr rare book reading room during its hours of operation. Requests for obtaining copies of these materials are subject to approval by designated staff members. Please see the <a href="https://library.columbia.edu/libraries/eastasian.html">Starr Library website</a> for more information on planning your visit.</p>
+</div>
+

--- a/app/views/repositories/reading_room/nncea/archives.html.erb
+++ b/app/views/repositories/reading_room/nncea/archives.html.erb
@@ -1,0 +1,5 @@
+<div class="row">
+	<h3>Archival Collections Portal</h3>
+	<p>View archival finding aids that include links to both open and restricted digital content.</p>
+	<%= render template: '_archives_search_form' %>
+</div>

--- a/app/views/repositories/reading_room/nncea/banner.html.erb
+++ b/app/views/repositories/reading_room/nncea/banner.html.erb
@@ -1,0 +1,28 @@
+<% if current_page?(repository_url(repository_key)) or current_page?(repository_reading_room_url(repository_id: repository_key)) %>
+	<div id="site-banner" class="slim">
+		<div class="row">
+			<div id="site-banner-inner">
+				<h1>Columbia University Libraries Digital Collections</h1>
+				<h2>C.V. Starr East Asian Library</h2>
+			</div>
+			<% if controller.reading_room_client? -%>
+				<div class="note">This workstation provides access to content that can only be viewed on-site in the reading room.</div>
+			<% end -%>
+		</div>
+	</div>
+<% else %>
+	<div id="site-banner" class="slim">
+		<div class="row">
+			<div id="site-banner-inner">
+				<div class="col-sm-3">
+					<a href="<%= repository_path(repository_key) %>">C.V. Starr East Asian Library</a>
+				</div>
+				<div class="col-sm-9">
+					<div id="search-navbar" class="navbar navbar-default slim" role="navigation">
+						<%= render template: '_search_form'  %>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+<% end %>

--- a/app/views/repositories/reading_room/nncea/footer.html.erb
+++ b/app/views/repositories/reading_room/nncea/footer.html.erb
@@ -1,0 +1,11 @@
+<footer class="container">
+	<hr />
+	<div class="row">
+		<div class="col-md-6">
+			<p><small>C.V. Starr East Asian Library &bull; 300 Kent Hall &bull; starr@library.columbia.edu</small></p>
+		</div>
+		<div class="col-md-6 text-right">
+			<p><small><%= link_to 'Copyright and Permissions', terms_of_use_url %> | <a href="#" onclick="return DCV.FeedbackModal.show();">Suggestions &amp; Feedback</a></small></p>
+		</div>
+	</div>
+</footer>

--- a/app/views/repositories/reading_room/nncea/highlights.html.erb
+++ b/app/views/repositories/reading_room/nncea/highlights.html.erb
@@ -1,0 +1,1 @@
+<!-- intentionally blank -->

--- a/app/views/repositories/reading_room/nncea/show.html.erb
+++ b/app/views/repositories/reading_room/nncea/show.html.erb
@@ -1,0 +1,15 @@
+<%
+template_key = params[:repository_id].downcase
+template_key.gsub!("-","")
+%>
+<div class="container">
+  <div id="sidebar" class="col-md-3">
+    <div class="inner">
+      <%= render template: "reading_room/#{template_key}/about", locals: {div_id: "home-sidebar-news"} %>
+    </div>
+  </div>
+  <div id="portals" class="col-md-9">
+    <%= render template: "reading_room/#{template_key}/archives" %>
+    <%= render template: 'reading_room/projects_and_exhibitions' %>
+  </div>
+</div>

--- a/app/views/repositories/reading_room/nncrb/about.html.erb
+++ b/app/views/repositories/reading_room/nncrb/about.html.erb
@@ -1,0 +1,8 @@
+<%
+div_id ||= "home-sidebar-news"
+%>
+<div id="<%= div_id %>">
+<p>A core objective of the Columbia University Libraries Rare Book &amp; Manuscript Library is to make our archival collections accessible for research and scholarship. However, certain digital items cannot be published online due to copyright restrictions or privacy and confidentiality concerns.</p>
+<p>These materials can only be consulted in the Rare Book &amp; Manuscript Library reading rooms. Please see the <a href="https://library.columbia.edu/libraries/rbml.html">Rare Books &amp; Manuscript Library website</a> for more information on planning your visit.
+</div>
+

--- a/app/views/repositories/reading_room/nncrb/archives.html.erb
+++ b/app/views/repositories/reading_room/nncrb/archives.html.erb
@@ -1,0 +1,5 @@
+<div class="row">
+	<h3>Archival Collections Portal</h3>
+	<p>View archival finding aids that include links to both open and restricted digital content.</p>
+	<%= render template: '_archives_search_form' %>
+</div>

--- a/app/views/repositories/reading_room/nncrb/banner.html.erb
+++ b/app/views/repositories/reading_room/nncrb/banner.html.erb
@@ -1,0 +1,28 @@
+<% if current_page?(repository_url(repository_key)) or current_page?(repository_reading_room_url(repository_id: repository_key)) %>
+	<div id="site-banner" class="slim">
+		<div class="row">
+			<div id="site-banner-inner">
+				<h1>Columbia University Libraries Digital Collections</h1>
+				<h2>Rare Book &amp; Manuscript Library</h2>
+			</div>
+			<% if controller.reading_room_client? -%>
+				<div class="note">This workstation provides access to content that can only be viewed on-site in the reading room.</div>
+			<% end -%>
+		</div>
+	</div>
+<% else %>
+	<div id="site-banner" class="slim">
+		<div class="row">
+			<div id="site-banner-inner">
+				<div class="col-sm-3">
+					<a href="<%= repository_path(repository_key) %>">Rare Book &amp; Manuscript Library</a>
+				</div>
+				<div class="col-sm-9">
+					<div id="search-navbar" class="navbar navbar-default slim" role="navigation">
+						<%= render template: '_search_form'  %>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+<% end %>

--- a/app/views/repositories/reading_room/nncrb/footer.html.erb
+++ b/app/views/repositories/reading_room/nncrb/footer.html.erb
@@ -1,0 +1,12 @@
+<footer class="container">
+	<hr />
+	<div class="row">
+		<div class="col-md-6">
+			<p><small>6th Floor East Butler Library &bull; 535 West 114th St.
+New York, NY 10027 &bull; rbml@library.columbia.edu</small></p>
+		</div>
+		<div class="col-md-6 text-right">
+			<p><small><%= link_to 'Order a Reproduction', 'http://library.columbia.edu/services/preservation/publications_policy.html' %> | <%= link_to 'Copyright and Permissions', terms_of_use_url %> | <a href="#" onclick="return DCV.FeedbackModal.show();">Suggestions &amp; Feedback</a></small></p>
+		</div>
+	</div>
+</footer>

--- a/app/views/repositories/reading_room/nncrb/highlights.html.erb
+++ b/app/views/repositories/reading_room/nncrb/highlights.html.erb
@@ -1,0 +1,1 @@
+<!-- intentionally blank -->

--- a/app/views/repositories/reading_room/nncrb/show.html.erb
+++ b/app/views/repositories/reading_room/nncrb/show.html.erb
@@ -1,0 +1,15 @@
+<%
+template_key = params[:repository_id].downcase
+template_key.gsub!("-","")
+%>
+<div class="container">
+  <div id="sidebar" class="col-md-3">
+    <div class="inner">
+      <%= render template: "reading_room/#{template_key}/about", locals: {div_id: "home-sidebar-news"} %>
+    </div>
+  </div>
+  <div id="portals" class="col-md-9">
+    <%= render template: "reading_room/#{template_key}/archives" %>
+    <%= render template: 'reading_room/projects_and_exhibitions' %>
+  </div>
+</div>

--- a/app/views/repositories/reading_room/nncrb/show.html.erb
+++ b/app/views/repositories/reading_room/nncrb/show.html.erb
@@ -7,6 +7,9 @@ template_key.gsub!("-","")
     <div class="inner">
       <%= render template: "reading_room/#{template_key}/about", locals: {div_id: "home-sidebar-news"} %>
     </div>
+    <div id="home-sidebar-about">
+		<p><a href="<%= about_url %>">Learn more about the DLC &raquo;</a></p>
+	</div>
   </div>
   <div id="portals" class="col-md-9">
     <%= render template: "reading_room/#{template_key}/archives" %>

--- a/app/views/repositories/reading_room/nynycap/about.html.erb
+++ b/app/views/repositories/reading_room/nynycap/about.html.erb
@@ -1,0 +1,8 @@
+<%
+div_id ||= "home-sidebar-news"
+%>
+<div id="<%= div_id %>">
+<p>Works from the art collections are available for research consultation and curricular use, and also may be requested as external loans for special exhibitions and for on-campus installation in selected  Columbia University department and staff offices.</p>
+<p>A core objective of the Columbia University Libraries Art Properties is to make our archival collections accessible for research and scholarship. However, certain digital items cannot be published online due to copyright restrictions.</p>
+<p>These materials can only be viewed in the Art Properties Reading Room during its hours of operation. To learn more about Art Properties and aspects of the University art collection, please visit the <a href="https://library.columbia.edu/libraries/avery/art-properties.html">Art Properties website</a>.</p>
+</div>

--- a/app/views/repositories/reading_room/nynycap/archives.html.erb
+++ b/app/views/repositories/reading_room/nynycap/archives.html.erb
@@ -1,0 +1,5 @@
+<div class="row">
+	<h3>Archival Collections Portal</h3>
+	<p>View archival finding aids that include links to both open and restricted digital content.</p>
+	<%= render template: '_archives_search_form' %>
+</div>

--- a/app/views/repositories/reading_room/nynycap/banner.html.erb
+++ b/app/views/repositories/reading_room/nynycap/banner.html.erb
@@ -1,0 +1,28 @@
+<% if current_page?(repository_url(repository_key)) or current_page?(repository_reading_room_url(repository_id: repository_key)) %>
+	<div id="site-banner" class="slim">
+		<div class="row">
+			<div id="site-banner-inner">
+				<h1>Columbia University Libraries Digital Collections</h1>
+				<h2>Art Properties</h2>
+			</div>
+			<% if controller.reading_room_client? -%>
+				<div class="note">This workstation provides access to content that can only be viewed on-site in the reading room.</div>
+			<% end -%>
+		</div>
+	</div>
+<% else %>
+	<div id="site-banner" class="slim">
+		<div class="row">
+			<div id="site-banner-inner">
+				<div class="col-sm-3">
+					<a href="<%= repository_path(repository_key) %>">Art Properties</a>
+				</div>
+				<div class="col-sm-9">
+					<div id="search-navbar" class="navbar navbar-default slim" role="navigation">
+						<%= render template: '_search_form'  %>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+<% end %>

--- a/app/views/repositories/reading_room/nynycap/footer.html.erb
+++ b/app/views/repositories/reading_room/nynycap/footer.html.erb
@@ -1,0 +1,11 @@
+<footer class="container">
+	<hr />
+	<div class="row">
+		<div class="col-md-6">
+			<p><small>300 Avery Hall &bull; artproperties@library.columbia.edu</small></p>
+		</div>
+		<div class="col-md-6 text-right">
+			<p><small><%= link_to 'Copyright and Permissions', terms_of_use_url %> | <a href="#" onclick="return DCV.FeedbackModal.show();">Suggestions &amp; Feedback</a></small></p>
+		</div>
+	</div>
+</footer>

--- a/app/views/repositories/reading_room/nynycap/highlights.html.erb
+++ b/app/views/repositories/reading_room/nynycap/highlights.html.erb
@@ -1,0 +1,1 @@
+<!-- intentionally blank -->

--- a/app/views/repositories/reading_room/nynycap/show.html.erb
+++ b/app/views/repositories/reading_room/nynycap/show.html.erb
@@ -1,0 +1,15 @@
+<%
+template_key = params[:repository_id].downcase
+template_key.gsub!("-","")
+%>
+<div class="container">
+  <div id="sidebar" class="col-md-3">
+    <div class="inner">
+      <%= render template: "reading_room/#{template_key}/about", locals: {div_id: "home-sidebar-news"} %>
+    </div>
+  </div>
+  <div id="portals" class="col-md-9">
+    <%= render template: "reading_room/#{template_key}/archives" %>
+    <%= render template: 'reading_room/projects_and_exhibitions' %>
+  </div>
+</div>

--- a/app/views/repositories/reading_room/nynycbl/about.html.erb
+++ b/app/views/repositories/reading_room/nynycbl/about.html.erb
@@ -1,0 +1,9 @@
+<%
+div_id ||= "home-sidebar-news"
+%>
+<div id="<%= div_id %>">
+<p>A core objective of the Columbia University Libraries is to make our archival collections accessible for research and scholarship. However, certain digital items cannot be published online due to copyright restrictions or privacy and confidentiality concerns.</p>
+<p>These materials can only be viewed in the Burke's Special Collections Reading Room during its hours of operation (M-F, 10-4:30).</p>
+<p>Requests for obtaining copies of these materials are subject to approval by designated staff members. Please see the <a href="https://library.columbia.edu/libraries/burke.html">Burke Library's homepage</a> for more information on planning your visit.</p>
+</div>
+

--- a/app/views/repositories/reading_room/nynycbl/archives.html.erb
+++ b/app/views/repositories/reading_room/nynycbl/archives.html.erb
@@ -1,0 +1,5 @@
+<div class="row">
+	<h3>Archival Collections Portal</h3>
+	<p>View archival finding aids that include links to both open and restricted digital content.</p>
+	<%= render template: '_archives_search_form' %>
+</div>

--- a/app/views/repositories/reading_room/nynycbl/banner.html.erb
+++ b/app/views/repositories/reading_room/nynycbl/banner.html.erb
@@ -1,0 +1,28 @@
+<% if current_page?(repository_url(repository_key)) or current_page?(repository_reading_room_url(repository_id: repository_key)) %>
+	<div id="site-banner" class="slim">
+		<div class="row">
+			<div id="site-banner-inner">
+				<h1>Columbia University Libraries Digital Collections</h1>
+				<h2>The Burke Library at Union Theological Seminary</h2>
+			</div>
+			<% if controller.reading_room_client? -%>
+				<div class="note">This workstation provides access to content that can only be viewed on-site in the reading room.</div>
+			<% end -%>
+		</div>
+	</div>
+<% else %>
+	<div id="site-banner" class="slim">
+		<div class="row">
+			<div id="site-banner-inner">
+				<div class="col-sm-3">
+					<a href="<%= repository_path(repository_key) %>">The Burke Library at Union Theological Seminary</a>
+				</div>
+				<div class="col-sm-9">
+					<div id="search-navbar" class="navbar navbar-default slim" role="navigation">
+						<%= render template: '_search_form'  %>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+<% end %>

--- a/app/views/repositories/reading_room/nynycbl/footer.html.erb
+++ b/app/views/repositories/reading_room/nynycbl/footer.html.erb
@@ -1,0 +1,11 @@
+<footer class="container">
+	<hr />
+	<div class="row">
+		<div class="col-md-6">
+			<p><small>The Burke Library at Union Theological Seminary &bull; 3041 Broadway &bull; burke@library.columbia.edu</small></p>
+		</div>
+		<div class="col-md-6 text-right">
+			<p><small><%= link_to 'Copyright and Permissions', terms_of_use_url %> | <a href="#" onclick="return DCV.FeedbackModal.show();">Suggestions &amp; Feedback</a></small></p>
+		</div>
+	</div>
+</footer>

--- a/app/views/repositories/reading_room/nynycbl/highlights.html.erb
+++ b/app/views/repositories/reading_room/nynycbl/highlights.html.erb
@@ -1,0 +1,1 @@
+<!-- intentionally blank -->

--- a/app/views/repositories/reading_room/nynycbl/show.html.erb
+++ b/app/views/repositories/reading_room/nynycbl/show.html.erb
@@ -1,0 +1,15 @@
+<%
+template_key = params[:repository_id].downcase
+template_key.gsub!("-","")
+%>
+<div class="container">
+  <div id="sidebar" class="col-md-3">
+    <div class="inner">
+      <%= render template: "reading_room/#{template_key}/about", locals: {div_id: "home-sidebar-news"} %>
+    </div>
+  </div>
+  <div id="portals" class="col-md-9">
+    <%= render template: "reading_room/#{template_key}/archives" %>
+    <%= render template: 'reading_room/projects_and_exhibitions' %>
+  </div>
+</div>

--- a/app/views/repositories/reading_room/nynycma/about.html.erb
+++ b/app/views/repositories/reading_room/nynycma/about.html.erb
@@ -1,0 +1,7 @@
+<%
+div_id ||= "home-sidebar-news"
+%>
+<div id="<%= div_id %>">
+<p>A core objective of the Columbia University Libraries Music &amp; Arts Library is to make our archival collections accessible for research and scholarship. However, certain digital items cannot be published online due to copyright restrictions or privacy and confidentiality concerns.</p>
+<p>These materials can only be consulted in the Music &amp; Arts Library reference reading area. Please see  the <a href="https://library.columbia.edu/libraries/music.html">Music &amp; Arts Library website</a> for more information on planning your visit.</p>
+</div>

--- a/app/views/repositories/reading_room/nynycma/archives.html.erb
+++ b/app/views/repositories/reading_room/nynycma/archives.html.erb
@@ -1,0 +1,5 @@
+<div class="row">
+	<h3>Archival Collections Portal</h3>
+	<p>View archival finding aids that include links to both open and restricted digital content.</p>
+	<%= render template: '_archives_search_form' %>
+</div>

--- a/app/views/repositories/reading_room/nynycma/banner.html.erb
+++ b/app/views/repositories/reading_room/nynycma/banner.html.erb
@@ -1,0 +1,28 @@
+<% if current_page?(repository_url(repository_key)) or current_page?(repository_reading_room_url(repository_id: repository_key)) %>
+<div id="site-banner" class="slim">
+	<div class="row">
+		<div id="site-banner-inner">
+			<h1>Columbia University Libraries Digital Collections</h1>
+			<h2>Music &amp; Arts Library</h2>
+		</div>
+		<% if controller.reading_room_client? -%>
+			<div class="note">This workstation provides access to content that can only be viewed on-site in the reading room.</div>
+		<% end -%>
+	</div>
+</div>
+<% else %>
+	<div id="site-banner" class="slim">
+		<div class="row">
+			<div id="site-banner-inner">
+				<div class="col-sm-3">
+					<a href="<%= repository_path(repository_key) %>">Music &amp; Arts Library</a>
+				</div>
+				<div class="col-sm-9">
+					<div id="search-navbar" class="navbar navbar-default slim" role="navigation">
+						<%= render template: '_search_form'  %>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+<% end %>

--- a/app/views/repositories/reading_room/nynycma/footer.html.erb
+++ b/app/views/repositories/reading_room/nynycma/footer.html.erb
@@ -1,0 +1,11 @@
+<footer class="container">
+	<hr />
+	<div class="row">
+		<div class="col-md-6">
+			<p><small>701 Dodge Hall &bull; musiclibrary@columbia.edu</small></p>
+		</div>
+		<div class="col-md-6 text-right">
+			<p><small><%= link_to 'Copyright and Permissions', terms_of_use_url %> | <a href="#" onclick="return DCV.FeedbackModal.show();">Suggestions &amp; Feedback</a></small></p>
+		</div>
+	</div>
+</footer>

--- a/app/views/repositories/reading_room/nynycma/highlights.html.erb
+++ b/app/views/repositories/reading_room/nynycma/highlights.html.erb
@@ -1,0 +1,2 @@
+<h4>Other Digital Collections in the Music &amp; Arts Library</h4>
+<p>The Creative Music Studio Archive, <a href="https://library.columbia.edu/libraries/music/ditson/about.html">Ditson Fund Recordings Archive</a>, and Shoichi Yui Collection may all be accessed by visiting the Music &amp; Arts Library. Please contact musiclibrary@columbia.edu to schedule your visit or for further information.</p>

--- a/app/views/repositories/reading_room/nynycma/show.html.erb
+++ b/app/views/repositories/reading_room/nynycma/show.html.erb
@@ -1,0 +1,20 @@
+<%
+template_key = params[:repository_id].downcase
+template_key.gsub!("-","")
+%>
+<div class="container">
+  <div id="sidebar" class="col-md-3">
+    <div class="inner">
+      <%= render template: "reading_room/#{template_key}/about", locals: {div_id: "home-sidebar-news"} %>
+    </div>
+  </div>
+  <div id="portals" class="col-md-6">
+    <%= render template: "reading_room/#{template_key}/archives" %>
+    <%= render template: 'reading_room/projects_and_exhibitions' %>
+  </div>
+  <div id="sidebar-right" class="col-md-3">
+    <div class="inner">
+      <%= render template: "reading_room/#{template_key}/highlights", locals: {div_id: "home-sidebar-highlights"} %>
+    </div>
+  </div>
+</div>

--- a/app/views/repositories/reading_room/projects_and_exhibitions.html.erb
+++ b/app/views/repositories/reading_room/projects_and_exhibitions.html.erb
@@ -16,6 +16,7 @@
 			<h4 itemprop="name">
 				<%= digital_project[:name] %>
 			</h4>
+			<p><%= (digital_project[:description] || '').html_safe %></p>
 			<div class="btn-group btn-group-justified" role="group">
 				<a class="btn btn-dark btn-xs" role="button" data-toggle="tooltip" title="More Information" href="#" data-proj-more="#proj-<%=proj_counter%>" data-proj-title="<%= digital_project[:name] %>" onclick="return DCV.ProjModal.show($(this).attr('data-proj-more'), $(this).attr('data-proj-title'));"><span class="glyphicon glyphicon-info-sign"></span></a>
 				<% if dcv_search_link.present? %>

--- a/app/views/repositories/reading_room/projects_and_exhibitions.html.erb
+++ b/app/views/repositories/reading_room/projects_and_exhibitions.html.erb
@@ -1,0 +1,37 @@
+<% digital_projects = controller.digital_projects(true) -%>
+<div class="row">
+	<h3>Digital Collections</h3>
+	<p>Search digital content available in the <%= I18n.t("ldpd.short.repo.#{params[:repository_id]}") %> reading room<%= ', or navigate via the links below' if digital_projects.present? -%>.</p>
+    <%= render template: '_search_form' %>
+</div>
+<div class="row" id="content">
+<% proj_counter = 0 %>
+<% digital_projects.each do |digital_project| %>
+	<% dcv_search_link = (digital_project[:facet_field].present? && digital_project[:facet_value].present?) ? repository_catalog_index_path(:f => {digital_project[:facet_field] => [digital_project[:facet_value]]}) : nil -%>
+	<div class="row document list-view compact" itemscope itemtype="http://schema.org/CreativeWork">
+		<div class="col-md-2">
+			<%= link_to image_tag(digital_project[:image], :class => 'thumbnail img-responsive', :itemprop => 'image', alt: digital_project[:name]), (dcv_search_link.present? ? dcv_search_link : digital_project[:external_url]), class: 'project-image-link' %>
+		</div>
+		<div class="col-md-9">
+			<h4 itemprop="name">
+				<%= digital_project[:name] %>
+			</h4>
+			<div class="btn-group btn-group-justified" role="group">
+				<a class="btn btn-dark btn-xs" role="button" data-toggle="tooltip" title="More Information" href="#" data-proj-more="#proj-<%=proj_counter%>" data-proj-title="<%= digital_project[:name] %>" onclick="return DCV.ProjModal.show($(this).attr('data-proj-more'), $(this).attr('data-proj-title'));"><span class="glyphicon glyphicon-info-sign"></span></a>
+				<% if dcv_search_link.present? %>
+					<%= link_to '<span class="glyphicon glyphicon-search"></span>'.html_safe, dcv_search_link, :class => 'btn btn-dark btn-xs', :"data-toggle" => 'tooltip', :title => 'Browse Content', :role => 'button' %>
+				<% end %>
+				<% if digital_project[:external_url].present? %>
+					<%= link_to '<span class="glyphicon glyphicon-new-window"></span>'.html_safe, digital_project[:external_url], :itemprop => 'url', :"data-toggle" => 'tooltip', :title => 'View Collection Site', :role => 'button', :class => 'btn btn-dark btn-xs' %>
+				<% end %>
+			</div>
+		</div>
+		<div class="col-md-1">
+			<div id="proj-<%=proj_counter%>" class="hide">
+				<div style="color:black;padding:30px;font-size:110%;" itemprop="description"><%= (digital_project[:description] || '').html_safe %></div>
+			</div>
+		</div>
+	</div>
+	<% proj_counter += 1 %>
+<% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,18 @@ Dcv::Application.routes.draw do
   get 'nyre/projects/:id' => 'nyre/projects#show', as: :nyre_project, constraints: { id: /(\d+)|([A-Z]{2,3}\.\d{3,4}\.[A-Z]+)/ }
 
   resources 'sites', only: [:index, :show], param: :slug
+
+  repositories = %w(NNC-A NNC-EA NNC-RB NyNyCAP NyNyCBL NyNyCMA)
+
+  repositories_constraint = lambda { |req| repositories.include?(req.params[:id]) || repositories.include?(req.params[:repository_id]) }
+  resources :repositories, path: '', constraints: repositories_constraint, shallow: true, only: [:show] do
+    get 'reading-room', as: 'reading_room', action: 'reading_room'
+    scope module: 'repositories' do
+      blacklight_for 'catalog', on: :member
+      subsite_for 'catalog', on: :member
+    end
+  end
+
   # Dynamic routes for catalog controller and all subsites
   # namespace configs must come first for routes to work
   (SUBSITES['public'].keys - ['uri']).each do |subsite_key|


### PR DESCRIPTION
The laptops deployed to the reading rooms are to be configured with dedicated homepages, with content described in DLC-677. This PR creates resources to support this (and more):
1. `/:marc_org_code` goes to a repository home page, currently immediately redirecting to the repository's reading room.
2. `/:marc_org_code/reading-room` goes to a dedicated page for the relevant reading room, with custom content and a list of sites associated with the repository.
3. `/:marc_org_code/catalog` is a Blacklight catalog pinned to searches for the repository's content.
4. searches to browse the DLC content of a restricted site now direct to the relevant repository catalog search, with a facet on either project or collection name per the site's configuration.