### PR TITLE
asset labels, child optimizations, performance optimizations

### DIFF
--- a/app/helpers/children_helper.rb
+++ b/app/helpers/children_helper.rb
@@ -2,18 +2,58 @@ module ChildrenHelper
   include Blacklight::BlacklightHelperBehavior
   include Blacklight::ConfigurationHelperBehavior
   include Dcv::ChildrenHelperBehavior
+
   def children(id=params[:parent_id], opts={})
     # get the document
     @response, @document = get_solr_response_for_doc_id(id)
     document_children_from_model(@document, opts)
   end
+
   def child(id=params[:id], opts={})
     # get the document
     @response, @document = get_solr_response_for_doc_id(id, {fl: '*'})
     child_from_solr(@document, document_show_link_field)
   end
-  def permitted_children(id=params[:parent_id], opts={})
+
+  def structured_children
+    @structured_children ||= begin
+      if @document['structured_bsi'] == true
+        children = structured_children_from_solr(@document) || structured_children_from_fedora(@document)
+      else
+        children = document_children_from_model(@document)[:children]
+        # just assign the order they came in, since there's no structure
+        children.each_with_index {|child, ix| child[:order] = ix + 1}
+      end
+
+      children.map! { |child| child.to_h.with_indifferent_access }
+      # the should be hashes from solr documents, with an added keys:
+      # - pid
+      # - title
+      # - order
+      # - thumbnail
+      # - dc_type
+      children
+    end
   end
-  def denied_children(id=params[:parent_id], opts={})
+
+  def has_unviewable_children?
+    structured_children.detect { |child| is_unviewable_child?(child) }
+  end
+
+  # is this child potentially viewable in a different location, or with a log in?
+  def is_unviewable_child?(child)
+    !can_access_asset?(child) && child.fetch(:access_control_levels_ssim,[]).detect { |val| !val.eql?('Closed') && !val.eql?('Embargoed') }
+  end
+
+  def has_viewable_children?
+    structured_children.detect { |child| can_access_asset?(child) }
+  end
+
+  def has_closed_children?
+    structured_children.detect { |child| !can_access_asset?(child) && child.fetch(:access_control_levels_ssim,[]).include?('Closed') }
+  end
+
+  def has_embargoed_children?
+    structured_children.detect { |child| !can_access_asset?(child) && child.fetch(:access_control_levels_ssim,[]).include?('Embargoed') }
   end
 end

--- a/app/helpers/children_helper.rb
+++ b/app/helpers/children_helper.rb
@@ -10,7 +10,7 @@ module ChildrenHelper
   def child(id=params[:id], opts={})
     # get the document
     @response, @document = get_solr_response_for_doc_id(id, {fl: '*'})
-    child_from_solr(@document)
+    child_from_solr(@document, document_show_link_field)
   end
   def permitted_children(id=params[:parent_id], opts={})
   end

--- a/app/helpers/children_helper.rb
+++ b/app/helpers/children_helper.rb
@@ -5,7 +5,7 @@ module ChildrenHelper
   def children(id=params[:parent_id], opts={})
     # get the document
     @response, @document = get_solr_response_for_doc_id(id)
-    document_children_from_model(opts)
+    document_children_from_model(@document, opts)
   end
   def child(id=params[:id], opts={})
     # get the document

--- a/app/helpers/dcv/catalog_helper_behavior.rb
+++ b/app/helpers/dcv/catalog_helper_behavior.rb
@@ -70,7 +70,7 @@ module Dcv::CatalogHelperBehavior
         fq: ["active_fedora_model_ssi:GenericResource"],
         facet: false
       }
-      response = Blacklight.default_index.connection.send_and_receive 'select', solr_params
+      response = controller.repository.connection.send_and_receive 'select', params: solr_params
       response['response']['numFound'].to_i
     end
   end

--- a/app/helpers/dcv/children_helper_behavior.rb
+++ b/app/helpers/dcv/children_helper_behavior.rb
@@ -48,17 +48,12 @@ module Dcv::ChildrenHelperBehavior
     children[:page] = children[:page]
     children[:count] = response['numFound'].to_i
     response['docs'].map do |doc|
-      children[:children] << child_from_solr(doc)
+      children[:children] << child_from_solr(doc, title_field)
     end
     children
   end
 
-  def child_from_solr(doc)
-    title_field = nil
-    begin
-      fl << (title_field = document_show_link_field).to_s
-    rescue
-    end
+  def child_from_solr(doc, title_field = nil)
     child = {id: doc['id'], pid: doc['id'], thumbnail: get_asset_url(id: doc['id'], size: 768, type: 'full', format: 'jpg')}
     if title_field
       title = doc[title_field.to_s]

--- a/app/helpers/dcv/children_helper_behavior.rb
+++ b/app/helpers/dcv/children_helper_behavior.rb
@@ -147,6 +147,7 @@ module Dcv::ChildrenHelperBehavior
     }
 
     response, docs = (defined? :controller) ? controller.search_results(_params) : search_results(_params)
+    title_field = (defined? :document_show_link_field) ? document_show_link_field : "title_ssm"
     proxies = response['response']['docs']
     proxies = Hash[proxies.map {|proxy| [proxy['proxyFor_ssi'], proxy]}]
 
@@ -163,11 +164,13 @@ module Dcv::ChildrenHelperBehavior
     kids.sort_by! {|kid| proxies[kid['proxy_id']]['index_ssi'].to_i}
     order = 0
     kids.map do |kid|
+      order += 1
+      kid_title = proxies[kid['proxy_id']]['label_ssi'] || Array(kid[title_field]).first || "Image #{order}"
       SolrDocument.new kid.merge({
         id: kid['id'],
         pid: kid['id'],
-        order: (order += 1),
-        title: proxies[kid['proxy_id']]['label_ssi'] || "Image #{order}",
+        order: order,
+        title: kid_title,
         thumbnail: get_asset_url(id: kid['id'], size: 256, type: 'full', format: 'jpg')
       })
     end

--- a/app/helpers/dcv/wowza_token_url_helper.rb
+++ b/app/helpers/dcv/wowza_token_url_helper.rb
@@ -2,10 +2,9 @@ module Dcv::WowzaTokenUrlHelper
   def wowza_media_token_url(asset_doc)
     asset_doc = SolrDocument.new(asset_doc) unless asset_doc.is_a? SolrDocument
     return unless can_access_asset?(asset_doc)
-    asset_pid = asset_doc[:pid] || asset_doc[:id]
     wowza_config = DCV_CONFIG['media_streaming']['wowza']
-    ds = Cul::Hydra::Fedora.ds_for_opts({pid: asset_pid, dsid: 'access'})
-    access_copy_location = ds.present? ? Addressable::URI.unencode(ds.dsLocation).gsub(/^file:/, '') : ''
+
+    access_copy_location = wowza_access_copy_location_from_solr(asset_doc) || wowza_access_copy_location_from_fcrepo(asset_doc)
 
     Wowza::SecureToken::Params.new({
       stream: wowza_config['application'] + '/_definst_/' + (access_copy_location.downcase.index('.mp3') ? 'mp3:' : 'mp4:') + access_copy_location.gsub(/^\//, ''),
@@ -15,5 +14,21 @@ module Dcv::WowzaTokenUrlHelper
       endtime: Time.now.to_i + wowza_config['token_lifetime'].to_i,
       prefix: wowza_config['token_prefix']
     }).to_url_with_token_hash(wowza_config['host'], wowza_config['ssl_port'], 'hls-ssl')
+  end
+
+  def wowza_access_copy_location_from_solr(asset_doc)
+    object_profile = Array(asset_doc['object_profile_ssm']).first
+    return nil if object_profile.blank?
+    object_profile = JSON.load(object_profile)
+    ds_profile = object_profile.dig("datastreams","access")
+    return nil if ds_profile.blank?
+    ds_location = ds_profile["dsLocation"]
+    ds_location.present? ? Addressable::URI.unencode(ds_location).gsub(/^file:/, '') : nil
+  end
+
+  def wowza_access_copy_location_from_fcrepo(asset_doc)
+    asset_pid = asset_doc[:pid] || asset_doc[:id]
+    ds = Cul::Hydra::Fedora.ds_for_opts({pid: asset_pid, dsid: 'access'})
+    ds.present? ? Addressable::URI.unencode(ds.dsLocation).gsub(/^file:/, '') : ''
   end
 end

--- a/app/helpers/show_field_display_field_helper.rb
+++ b/app/helpers/show_field_display_field_helper.rb
@@ -13,4 +13,25 @@ module ShowFieldDisplayFieldHelper
     (field_config.except || []).include? field_config.field
   end
 
+  # return the Blacklight::AbstractRepository in scope
+  def doc_repository
+    if defined?(:controller)
+      controller.repository
+    elsif defined?(:repository)
+      repository
+    else
+      Blacklight.default_index
+    end
+  end
+
+  # return a cache key for the field given the Blacklight::AbstractRepository in scope
+  def repository_cache_key(field_name)
+    if defined?(:controller) || defined?(:repository)
+      core = doc_repository.connection.uri.to_s.split('/')[-1]
+      cache_key = "dcv.#{field_name}.#{core}"
+    else
+      doc_repository = Blacklight.default_index
+      cache_key = "dcv.#{field_name}.default"
+    end
+  end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -11,8 +11,6 @@ class SolrDocument
 
   include Blacklight::Solr::Document
 
-  # self.unique_key = 'id'
-
   # Email uses the semantic field mappings below to generate the body of an email.
   SolrDocument.use_extension( Blacklight::Document::Email )
 
@@ -26,39 +24,9 @@ class SolrDocument
   # Recommendation: Use field names from Dublin Core
   use_extension( Blacklight::Document::DublinCore)
 
-  # Aggregate item in context urls for this solr doc and its children, returning a hash that maps pids to item in context urls
-  def self_and_child_pids_to_item_in_context_urls
-    return @self_and_child_pids_to_item_in_context_urls ||= begin
-      pids_to_urls = {}
-      pids_to_urls[self['id']] = item_in_context_url if item_in_context_url.present?
-
-      pids_to_urls.merge(child_pids_to_item_in_context_urls)
-    end
-  end
-
   # Item in context url for this solr document. Might return nil if this doc has no item in context url.
   def item_in_context_url
     self['lib_item_in_context_url_ssm'].present? ? self['lib_item_in_context_url_ssm'].first : nil
-  end
-
-  def child_pids_to_item_in_context_urls
-    return @child_pids_to_item_in_context_urls ||= begin
-      pids_to_urls = {}
-      search_response = Blacklight.default_index.connection.send_and_receive 'select', {
-        :q  => '*:*',
-        :fl => 'id,lib_item_in_context_url_ssm',
-        :qt => 'search',
-        :fq => [
-          'cul_member_of_ssim:"info:fedora/' + self['id'] + '"'
-        ],
-        :rows => 999,
-        :facet => false
-      }
-      search_response['response']['docs'].each do |doc|
-        pids_to_urls[doc['id']] = doc['lib_item_in_context_url_ssm'].first if doc['lib_item_in_context_url_ssm'].present?
-      end
-      pids_to_urls
-    end
   end
 
   def site_result?

--- a/app/views/catalog/content_aggregator/carousel/_structured_children.html.erb
+++ b/app/views/catalog/content_aggregator/carousel/_structured_children.html.erb
@@ -6,7 +6,7 @@
       <% next if child[:pid].blank? # Skip rendering of unpublished children %>
       <% can_access = can_access_asset?(child.with_indifferent_access) # Skip rendering of unavailable children %>
       <% child_title = child[:title].present? ? child[:title].strip : '' %>
-      <% item_in_context_url = document.self_and_child_pids_to_item_in_context_urls.key?(child[:id]) ? document.self_and_child_pids_to_item_in_context_urls[child[:id]] : document.item_in_context_url %>
+      <% item_in_context_url = Array(child[:lib_item_in_context_url_ssm]).first || document.item_in_context_url %>
       <div class="item <%= ix == 0 ? 'active' : '' %>"
         data-child-number="<%= ix %>"
         data-child-title="<%= child_title == parent_title || child_title.blank? ? '&nbsp'.html_safe : h(child_title) %>"

--- a/config/initializers/subsites.rb
+++ b/config/initializers/subsites.rb
@@ -11,8 +11,7 @@ begin
     fq: ["dc_type_sim:\"Publish Target\"","active_fedora_model_ssi:Concept"],
     facet: false
     }
-    key = :params
-    res = rsolr.send_and_receive('select', {key=>solr_params.to_hash, method: :get})
+    res = rsolr.send_and_receive('select', params: solr_params.to_hash, method: :get)
     solr_response = Blacklight::Solr::Response.new(res, solr_params, solr_document_model: SolrDocument)
     docs = solr_response['response']['docs']
     docs.each do |doc|

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -88,8 +88,14 @@ describe CatalogHelper, :type => :helper do
         }
       }
     }
+    let(:repository) { double(Blacklight::Solr::Repository) }
+    let(:rsolr_connection) { double(RSolr::Client) }
+    before do
+      allow(controller).to receive(:repository).and_return(repository)
+      allow(repository).to receive(:connection).and_return(rsolr_connection)
+      allow(rsolr_connection).to receive(:send_and_receive).and_return(solr_response)
+    end
     it do
-      allow(Blacklight.default_index.connection).to receive(:send_and_receive).and_return(solr_response)
       expect(helper.total_dcv_asset_count).to eq(12345)
     end
   end


### PR DESCRIPTION
use asset title if label is absent from struct map
use controller-context solr connection rather than global default
attempt to use solr for dslocation of access media before calling out to Fedora
overhaul child asset negotiation to remove extraneous solr requests
