### PR TITLE
fix reading room home page thumbnail css classes (DLC-794)

### DIFF
--- a/app/views/repositories/reading_room/projects_and_exhibitions.html.erb
+++ b/app/views/repositories/reading_room/projects_and_exhibitions.html.erb
@@ -9,8 +9,8 @@
 <% digital_projects.each do |digital_project| %>
 	<% dcv_search_link = (digital_project[:facet_field].present? && digital_project[:facet_value].present?) ? search_repository_catalog_path(:f => {digital_project[:facet_field] => [digital_project[:facet_value]]}) : nil -%>
 	<div class="row document list-view compact" itemscope itemtype="http://schema.org/CreativeWork">
-		<div class="col-md-2">
-			<%= link_to image_tag(digital_project[:image], :class => 'thumbnail img-responsive', :itemprop => 'image', alt: digital_project[:name]), (dcv_search_link.present? ? dcv_search_link : digital_project[:external_url]), class: 'project-image-link' %>
+		<div class="col-md-2 thumbnail">
+			<%= link_to image_tag(digital_project[:image], :class => 'img-responsive img-square', :itemprop => 'image', alt: digital_project[:name]), (dcv_search_link.present? ? dcv_search_link : digital_project[:external_url]), class: 'project-image-link' %>
 		</div>
 		<div class="col-md-9">
 			<h4 itemprop="name">


### PR DESCRIPTION
- img includes class image-square
- thumbnail class moved to container so that width doesn't hide image

see http://localhost:3000/NNC-RB/reading-room