### PR TITLE
reimplement tinydraggable on feedback colorbox modal (DLC-247)

### DIFF
--- a/app/assets/javascripts/dcv.js.erb
+++ b/app/assets/javascripts/dcv.js.erb
@@ -176,6 +176,7 @@ function setupChildViewer() {
 	    opacity:".6",
 	    fixed:true,
 	    iframe:true,
+      close: '\ue014',
 	    preloading: false
 	  });
 	});

--- a/app/assets/javascripts/dcv/dcv.general.js
+++ b/app/assets/javascripts/dcv/dcv.general.js
@@ -151,8 +151,6 @@ DCV.FeedbackModal.show = function(){
 
   var feedbackUrl = window.CULh_feedback_url || 'https://feedback.cul.columbia.edu/feedback_submission/dlc';
 
-  console.log(feedbackUrl);
-
   $.colorbox({
     href: feedbackUrl + '?submitted_from_page=' + encodeURIComponent(document.URL) + '&window_width=' + $(window).width() + '&window_height=' + $(window).height(),
     className: 'cul-no-colorbox-title-bar',

--- a/app/assets/javascripts/dcv/dcv.general.js
+++ b/app/assets/javascripts/dcv/dcv.general.js
@@ -136,7 +136,9 @@ DCV.FeedbackModal.onComplete = function(){
             $(document).on('mousemove.drag', function(e){
                 $('#colorbox').offset({ top: e.pageY-dy, left: e.pageX-dx } );
             });
-        },
+        }
+    });
+    $('#colorbox').on({
         mouseup: function(){ $(document).unbind('mousemove.drag'); $('#cboxDrag').blur(); }
     });
 };

--- a/app/assets/javascripts/dcv/dcv.general.js
+++ b/app/assets/javascripts/dcv/dcv.general.js
@@ -83,6 +83,7 @@ DCV.ProjModal.show = function(displayUrl, downloadUrl){
     fixed:true,
     inline:true,
     preloading: false,
+    close: '\ue014',
     title: downloadUrl,
     onClosed: function() {
          $(displayUrl).addClass('hide');
@@ -114,6 +115,7 @@ DCV.ModsDownloadModal.show = function(displayUrl, downloadUrl){
     fixed:true,
     iframe:true,
     preloading: false,
+    close: '\ue014',
     title: '<a href="' + downloadUrl + '" data-no-turbolink="true"><span class="glyphicon glyphicon-download"></span> Download XML</a>'
   });
 
@@ -125,6 +127,26 @@ DCV.ModsDownloadModal.show = function(displayUrl, downloadUrl){
  **************/
 
 DCV.FeedbackModal = {};
+// see also https://pixabay.com/blog/posts/draggable-jquery-colorbox-52/
+DCV.FeedbackModal.onComplete = function(){
+    $('#cboxDrag').on({
+        mousedown: function(e){
+            var os = $('#colorbox').offset(),
+                dx = e.pageX-os.left, dy = e.pageY-os.top;
+            $(document).on('mousemove.drag', function(e){
+                $('#colorbox').offset({ top: e.pageY-dy, left: e.pageX-dx } );
+            });
+        },
+        mouseup: function(){ $(document).unbind('mousemove.drag'); $('#cboxDrag').blur(); }
+    });
+};
+DCV.FeedbackModal.onLoad = function(){
+  var cboxDrag = "<button id='cboxDrag' type='button'>&#xe068;</button>";
+  $(cboxDrag).insertBefore($('#cboxClose'));
+};
+DCV.FeedbackModal.onClosed = function(){
+  $('#cboxDrag').remove();
+};
 DCV.FeedbackModal.show = function(){
 
   var feedbackUrl = window.CULh_feedback_url || 'https://feedback.cul.columbia.edu/feedback_submission/dlc';
@@ -143,7 +165,11 @@ DCV.FeedbackModal.show = function(){
     iframe:true,
     preloading: false,
     current: false,
-    title: false
+    title: false,
+    close: '\ue014',
+    onLoad: DCV.FeedbackModal.onLoad,
+    onComplete: DCV.FeedbackModal.onComplete,
+    onClosed: DCV.FeedbackModal.onClosed
   });
 
   return false;
@@ -167,6 +193,7 @@ DCV.CitationDisplayModal.show = function(citationDisplayUrl, modalLabel){
     iframe:true,
     preloading: false,
     current:"{current} of {total}",
+    close: '\ue014',
     title: modalLabel
   });
 
@@ -190,9 +217,9 @@ DCV.ZoomingImageModal.show = function(){
     fixed:true,
     iframe:true,
     preloading: false,
+    close: '\ue014',
     current:"{current} of {total}"
   });
-  //$('#colorbox').tinyDraggable({handle:'#cboxTitle', exclude:'input, textarea, a, button, i'});
 
   return false;
 };

--- a/app/assets/stylesheets/_base_layout.scss
+++ b/app/assets/stylesheets/_base_layout.scss
@@ -1,8 +1,7 @@
 // bs4 compat
 @import './_bs4_compat.scss';
-
 //fonts
-$font_glyphs: Glyphicons Halflings;
+$font_glyphs: "Glyphicons Halflings";
 
 //urls
 $url_crown_small: url(//cdn.cul.columbia.edu/ldpd-toolkit/img/crown-bts-24x24.png);
@@ -85,6 +84,19 @@ $url_brand_svg: url(//cdn.cul.columbia.edu/ldpd-toolkit/fonts/trajanpro-regular-
 	color: $color_highlight;
 	background-color: $color_highlight_background;
 	border-color: $color_highlight_background;
+}
+
+%cbox_buttons {
+	top: 0;
+	font-family: $font_glyphs;
+	font-style: normal;
+	font-weight: normal;
+	color: $color_highlight;
+	background-color: $color_highlight_background;
+	&:hover, &:focus {
+		color: $color_highlight_background;
+		background-color: $color_highlight;
+	}
 }
 
 body {
@@ -954,8 +966,10 @@ h2[itemprop="name"] {
 
 #colorbox {
 	#cboxClose {
-		top: 0;
-		background-color: $color_highlight_background;
+		@extend %cbox_buttons;
+	}
+	#cboxDrag {
+		@extend %cbox_buttons;
 		border-bottom-left-radius: 4px;
 	}
 	#cboxCurrent {

--- a/app/assets/stylesheets/dcv/dcv.css.scss
+++ b/app/assets/stylesheets/dcv/dcv.css.scss
@@ -927,6 +927,13 @@ h2[itemprop="name"] {
 	#cboxClose {
 		top: 0;
 		background-color: $color_9;
+		font-family: "Glyphicons Halflings";
+	}
+	#cboxDrag {
+		top: 0;
+		right: 27px;
+		background-color: $color_9;
+		font-family: "Glyphicons Halflings";
 		border-bottom-left-radius: 4px;
 	}
 	#cboxCurrent {

--- a/app/assets/stylesheets/shared/colorbox.css.scss
+++ b/app/assets/stylesheets/shared/colorbox.css.scss
@@ -10,7 +10,7 @@
 #cboxLoadedContent{overflow:auto; -webkit-overflow-scrolling: touch;}
 #cboxTitle{margin:0;}
 #cboxLoadingOverlay, #cboxLoadingGraphic{position:absolute; top:0; left:0; width:100%; height:100%;}
-#cboxPrevious, #cboxNext, #cboxClose, #cboxSlideshow{cursor:pointer;}
+#cboxPrevious, #cboxNext, #cboxClose, #cboxDrag, #cboxSlideshow{cursor:pointer;}
 .cboxPhoto{float:left; margin:auto; border:0; display:block; max-width:none; -ms-interpolation-mode:bicubic;}
 .cboxIframe{width:100%; height:100%; display:block; border:0; padding:0; margin:0;}
 #colorbox, #cboxContent, #cboxLoadedContent{box-sizing:content-box; -moz-box-sizing:content-box; -webkit-box-sizing:content-box;}
@@ -50,8 +50,8 @@
         #cboxPrevious:hover{background-position:-75px -25px;}
         #cboxNext{position:absolute; bottom:0; left:27px; background:image-url('dcv/images/controls.png') no-repeat -50px 0; width:25px; height:25px; text-indent:-9999px;}
         #cboxNext:hover{background-position:-50px -25px;}
-        #cboxClose{position:absolute; bottom:0; right:0; background:image-url('dcv/images/controls.png') no-repeat -25px 0; width:25px; height:25px; text-indent:-9999px;}
-        #cboxClose:hover{background-position:-25px -25px;}
+        #cboxDrag{position:absolute; bottom:0; right:27px; background:inherit; width:25px; height:25px;text-indent: inherit;border:0;margin:0;padding:0;overflow:visible;}
+        #cboxClose{position:absolute; bottom:0; right:0; background:inherit; width:25px; height:25px; text-indent: inherit;}
 
 /*
   The following fixes a problem where IE7 and IE8 replace a PNG's alpha transparency with a black fill


### PR DESCRIPTION
- Replace colorbox background images with glyphicon font icons
- Add palette-appropriate styles