### PR TITLE
DLC-972 facet field names DLC-971 show view with format parameter

### DIFF
--- a/app/controllers/sites/search_configuration_controller.rb
+++ b/app/controllers/sites/search_configuration_controller.rb
@@ -44,7 +44,7 @@ module Sites
 					date_search_configuration: [:enabled, :granularity_search, :show_sidebar, :show_timeline, :sidebar_label],
 					map_configuration: [:default_lat, :default_long, :enabled, :granularity_data, :granularity_search, :show_items, :show_sidebar],
 					display_options: [:default_search_mode, :show_csv_results, :show_original_file_download, :show_other_sources],
-					facets: [:field_name, :label, :limit, :sort, :value_transforms],
+					facets: [:facet_fields_form_value, :label, :limit, :sort, :value_transforms],
 					search_fields: [:type, :label]
 			)&.to_h
 			# todo: find a better way to unroll the list of values

--- a/app/controllers/sites/search_configuration_controller.rb
+++ b/app/controllers/sites/search_configuration_controller.rb
@@ -23,7 +23,6 @@ module Sites
 			rescue ActiveRecord::RecordInvalid => ex
 				flash[:alert] = ex.message
 			end
-			@subsite.save! if @subsite.changed?
 			if restricted?
 				redirect_to edit_restricted_site_search_configuration_path(site_slug: @subsite.slug.sub('restricted/', ''))
 			else

--- a/app/models/concerns/solr_document/field_semantics.rb
+++ b/app/models/concerns/solr_document/field_semantics.rb
@@ -1,0 +1,20 @@
+module SolrDocument::FieldSemantics
+	def self.included(mod)
+		# DublinCore uses the semantic field mappings below to assemble an OAI-compliant Dublin Core document
+		# Semantic mappings of solr stored fields. Fields may be multi or
+		# single valued. See Blacklight::Solr::Document::ExtendableClassMethods#field_semantics
+		# and Blacklight::Solr::Document#to_semantic_values
+		# Recommendation: Use field names from Dublin Core
+		mod.use_extension( Blacklight::Document::DublinCore)
+		# Normalized field names
+		mod.field_semantics.merge!(
+			identifier: 'ezid_doi_ssim',
+			title: 'title_display_ssm',
+			creator: 'primary_name_sim',
+			format: 'lib_format_ssm',
+			type: 'type_of_resource_ssm',
+			subject: 'lib_all_subjects_ssm',
+			description: 'abstract_ssm'
+		)
+	end
+end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -14,6 +14,7 @@ class Site < ApplicationRecord
 
 	validates :search_type, inclusion: { in: VALID_SEARCH_TYPES }
 	validates :layout, inclusion: { in: VALID_LAYOUTS }
+	validates_with DelegatingValidator, fields: [:search_configuration]
 
 	configure_blacklight do |config|
 		Dcv::Configurators::DcvBlacklightConfigurator.configure_default_solr_params(config)

--- a/app/models/site/facet_configuration.rb
+++ b/app/models/site/facet_configuration.rb
@@ -52,7 +52,6 @@ class Site::FacetConfiguration
 		self.pivot = vals.length > 1 ? vals[1..-1] : nil
 	end
 
-
 	def value_transforms=(val)
 		val = clean_and_freeze_validated_array(val, VALID_VALUE_TRANSFORMS)
 		value_transforms_will_change! unless val == @value_transforms
@@ -86,7 +85,7 @@ class Site::FacetConfiguration
 	end
 
 	def configure(blacklight_config)
-		return false if blacklight_config.facet_fields[@field_name]
+		return false if @field_name.blank? || blacklight_config.facet_fields[@field_name]
 		opts = {label: @label, limit: @limit, sort: @sort}
 		if @exclusions.present?
 			opts[:cul_custom_value_hide] = Array(@exclusions)

--- a/app/models/site/facet_configuration.rb
+++ b/app/models/site/facet_configuration.rb
@@ -103,4 +103,10 @@ class Site::FacetConfiguration
 		end
 		blacklight_config.add_facet_field @field_name, opts
 	end
+
+	def validate(attr_name, errors)
+		if @field_name.blank?
+			errors.add (Array(attr_name) << :field_name).join('/'), "Facet field name cannot be blank"
+		end
+	end
 end

--- a/app/models/site/search_configuration.rb
+++ b/app/models/site/search_configuration.rb
@@ -57,6 +57,12 @@ class Site::SearchConfiguration
 		false
 	end
 
+	def validate(attr_name, errors)
+		if @facets.present?
+			@facets.each { |facet_config| facet_config.validate(Array(attr_name) << :facets, errors) }
+		end
+	end
+
 	class Type <  ActiveModel::Type::Value
 		include ActiveModel::Type::Helpers::Mutable
 

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -10,6 +10,7 @@ class SolrDocument
   ]
 
   include Blacklight::Solr::Document
+  include SolrDocument::FieldSemantics
   include SolrDocument::PublicationInfo
   include SolrDocument::Snippets
 
@@ -18,13 +19,6 @@ class SolrDocument
 
   # SMS uses the semantic field mappings below to generate the body of an SMS email.
   SolrDocument.use_extension( Blacklight::Document::Sms )
-
-  # DublinCore uses the semantic field mappings below to assemble an OAI-compliant Dublin Core document
-  # Semantic mappings of solr stored fields. Fields may be multi or
-  # single valued. See Blacklight::Solr::Document::ExtendableClassMethods#field_semantics
-  # and Blacklight::Solr::Document#to_semantic_values
-  # Recommendation: Use field names from Dublin Core
-  use_extension( Blacklight::Document::DublinCore)
 
   # Item in context url for this solr document. Might return nil if this doc has no item in context url.
   def item_in_context_url

--- a/app/validators/delegating_validator.rb
+++ b/app/validators/delegating_validator.rb
@@ -1,0 +1,6 @@
+class DelegatingValidator < ActiveModel::Validator
+	def validate(record)
+		return unless options[:fields].any?
+		options[:fields].each { |field| record.send(field).validate(field, record.errors) }
+	end
+end

--- a/app/views/sites/permissions/_form.html.erb
+++ b/app/views/sites/permissions/_form.html.erb
@@ -7,7 +7,7 @@
 	end
 -%>
 <%= form_for @subsite, url: config_view, builder: ::ValueIndexableFormBuilder do |site_form| %>
-	<div class="panel border-secondary">
+	<div class="card border-secondary">
 		<div class="card-header swatch-secondary"><h2 class="card-title">Site Editor IDs</h2></div>
 		<div class="card-body site_editors">
 			<div class="form-group">
@@ -18,7 +18,7 @@
 		</div>
 	</div>
 	<%- if !@subsite.restricted %>
-		<div class="panel bg-danger">
+		<div class="card bg-danger">
 			<div class="card-header"><h2 class="card-title">Configuration Will Not Apply!</h2></div>
 			<div class="card-body">The properties configured below are for restricted sites, but <%= @subsite.slug %> is a public site. If this is an error, please contact dlc-support@library.columbia.edu.</div>
 		</div>

--- a/app/views/sites/search_configuration/_date_range_form.html.erb
+++ b/app/views/sites/search_configuration/_date_range_form.html.erb
@@ -1,6 +1,6 @@
 <%= config_form.fields_for :date_search_configuration, @subsite.search_configuration.date_search_configuration do |date_form| %>
-	<div class="card swatch-secondary">
-		<div class="card-header"><span class="card-title">Enable/Disable Result Displays</span></div>
+	<div class="card swatch-body">
+		<div class="card-header swatch-info"><span class="card-title">Enable/Disable Result Displays</span></div>
 		<div class="card-body">
 			<div class="form-group">
 				<label for="site_search_configuration_date_search_configuration_show_timeline">Show Timeline Search Results <span class="fa fa-question-circle" data-tooltip="tooltip-date-show-timeline"></span></label>
@@ -8,8 +8,8 @@
 			</div>
 		</div>
 	</div>
-	<div class="card swatch-secondary">
-		<div class="card-header"><span class="card-title">Sidebar Interface Configuration</span></div>
+	<div class="card swatch-body">
+		<div class="card-header swatch-info"><span class="card-title">Sidebar Interface Configuration</span></div>
 		<div class="card-body">
 			<div class="form-group">
 				<label for="site_search_configuration_date_search_configuration_show_sidebar">Show Date Range Sidebar <span class="fa fa-question-circle" data-tooltip="tooltip-date-show-sidebar"></span></label>

--- a/app/views/sites/search_configuration/_display_options_form.html.erb
+++ b/app/views/sites/search_configuration/_display_options_form.html.erb
@@ -1,6 +1,6 @@
 <%= config_form.fields_for :display_options, @subsite.search_configuration.display_options do |options_form| %>
-	<div class="card swatch-secondary">
-		<div class="card-header"><span class="card-title">Search Results Display Options</span></div>
+	<div class="card swatch-body">
+		<div class="card-header swatch-info"><span class="card-title">Search Results Display Options</span></div>
 		<div class="card-body">
 			<div class="form-group">
 				<label for="site_search_configuration_display_options[default_search_mode]">Default Search Mode <span class="fa fa-question-circle" data-tooltip="tooltip-display-search-mode"></span></label>
@@ -25,8 +25,8 @@
 			</div>
 		</div>
 	</div>
-	<div class="card swatch-secondary">
-		<div class="card-header"><span class="card-title">Item Display Options</span></div>
+	<div class="card swatch-body">
+		<div class="card-header swatch-info"><span class="card-title">Item Display Options</span></div>
 		<div class="card-body">
 			<div class="form-group">
 				<label for="site_search_configuration_display_options_show_original_file_download">Allow Original File Downloads <span class="fa fa-question-circle" data-tooltip="tooltip-display-original-files"></span></label>

--- a/app/views/sites/search_configuration/_facet_field_form.html.erb
+++ b/app/views/sites/search_configuration/_facet_field_form.html.erb
@@ -2,9 +2,9 @@
 	<div class="card-header form-inline">
 		<div class="card-header"><span class="card-title"><%= field_form.object.new_record? ? "New Facet" : field_form.object.label %></span></div>
 	</div>
-	<div class="card-body" id="search_fields_<%= field_form.index %>_atts">
+	<div class="card-body" id="facet_fields_<%= field_form.index %>_atts">
 		<div class="form-group">
-			<label for="site[search_configuration][facets][<%= field_form.index %>][label]">Field Name <span class="fa fa-question-circle" data-tooltip="tooltip-facets-field"></span></label>
+			<label for="site[search_configuration][facets][<%= field_form.index %>][facet_fields_form_value]">Field Name <span class="fa fa-question-circle" data-tooltip="tooltip-facets-field"></span></label>
 			<%= field_form.text_field :facet_fields_form_value %>
 		</div>
 		<div class="form-group">
@@ -16,7 +16,7 @@
 			<%= field_form.text_field :limit %>
 		</div>
 		<div class="form-group">
-			<label for="site[search_configuration][facets][<%= field_form.index %>][limit]">Value Sort <span class="fa fa-question-circle" data-tooltip="tooltip-facets-sort"></span></label>
+			<label for="site[search_configuration][facets][<%= field_form.index %>][sort]">Value Sort <span class="fa fa-question-circle" data-tooltip="tooltip-facets-sort"></span></label>
 			<%= field_form.select :sort, Site::FacetConfiguration::VALID_SORTS %>
 		</div>
 		<div class="form-group">

--- a/app/views/sites/search_configuration/_facet_field_form.html.erb
+++ b/app/views/sites/search_configuration/_facet_field_form.html.erb
@@ -1,5 +1,5 @@
-<div class="form-group card swatch-info facet_field" id="facet_fields_<%= field_form.index %>">
-	<div class="card-header form-inline">
+<div class="form-group card border-info facet_field" id="facet_fields_<%= field_form.index %>">
+	<div class="card-header swatch-info form-inline">
 		<div class="card-header"><span class="card-title"><%= field_form.object.new_record? ? "New Facet" : field_form.object.label %></span></div>
 	</div>
 	<div class="card-body" id="facet_fields_<%= field_form.index %>_atts">

--- a/app/views/sites/search_configuration/_form.html.erb
+++ b/app/views/sites/search_configuration/_form.html.erb
@@ -8,32 +8,32 @@
 -%>
 <%= form_for @subsite, url: config_view, builder: ::ValueIndexableFormBuilder do |site_form| %>
 	<%= site_form.fields_for :search_configuration, @subsite.search_configuration do |config_form| %>
-		<div class="card swatch-secondary">
-			<div class="card-header"><h2 class="card-title">Display Options</h2></div>
+		<div class="card">
+			<div class="card-header swatch-secondary"><h2 class="card-title">Display Options</h2></div>
 			<div class="card-body display_options">
 				<%= render partial: 'sites/search_configuration/display_options_form', locals: {config_form: config_form} %>
 			</div>
 		</div>
-		<div class="card swatch-secondary">
-			<div class="card-header"><h2 class="card-title">Map Configuration</h2></div>
+		<div class="card">
+			<div class="card-header swatch-secondary"><h2 class="card-title">Map Configuration</h2></div>
 			<div class="card-body map_configuration">
 				<%= render partial: 'sites/search_configuration/map_form', locals: {config_form: config_form} %>
 			</div>
 		</div>
-		<div class="card swatch-secondary">
-			<div class="card-header"><h2 class="card-title">Date Range Search Configuration</h2></div>
+		<div class="card">
+			<div class="card-header swatch-secondary"><h2 class="card-title">Date Range Search Configuration</h2></div>
 			<div class="card-body date_search_configuration">
 				<%= render partial: 'sites/search_configuration/date_range_form', locals: {config_form: config_form} %>
 			</div>
 		</div>
-		<div class="card swatch-secondary">
-			<div class="card-header"><h2 class="card-title">Facet Field Configuration</h2></div>
+		<div class="card">
+			<div class="card-header swatch-secondary"><h2 class="card-title">Facet Field Configuration</h2></div>
 			<div class="card-body facet_fields">
 				<%= render partial: 'sites/search_configuration/facet_fields_form', locals: {config_form: config_form} %>
 			</div>
 		</div>
-		<div class="card swatch-secondary">
-			<div class="card-header"><h2 class="card-title">Search Field Configuration</h2></div>
+		<div class="card">
+			<div class="card-header swatch-secondary"><h2 class="card-title">Search Field Configuration</h2></div>
 			<div class="card-body search_fields">
 				<%= render partial: 'sites/search_configuration/search_fields_form', locals: {config_form: config_form} %>
 			</div>

--- a/app/views/sites/search_configuration/_map_form.html.erb
+++ b/app/views/sites/search_configuration/_map_form.html.erb
@@ -1,6 +1,6 @@
 <%= config_form.fields_for :map_configuration, @subsite.search_configuration.map_configuration do |map_form| %>
-	<div class="card swatch-secondary">
-		<div class="card-header"><span class="card-title">Enable/Disable Result Displays</span></div>
+	<div class="card swatch-body">
+		<div class="card-header swatch-info"><span class="card-title">Enable/Disable Result Displays</span></div>
 		<div class="card-body">
 			<div class="form-group">
 				<label for="site_search_configuration_map_configuration_enabled">Enabled <span class="fa fa-question-circle" data-tooltip="tooltip-map-enable"></span></label>
@@ -12,8 +12,8 @@
 			</div>
 		</div>
 	</div>
-	<div class="card swatch-secondary">
-		<div class="card-header"><span class="card-title">Map Interface Configuration</span></div>
+	<div class="card swatch-body">
+		<div class="card-header swatch-info"><span class="card-title">Map Interface Configuration</span></div>
 		<div class="card-body">
 			<div class="form-group">
 				<label for="site_search_configuration_map_configuration_default_lat">Default Latitude <span class="fa fa-question-circle" data-tooltip="tooltip-map-default-coords"></span></label>

--- a/app/views/sites/search_configuration/_search_field_form.html.erb
+++ b/app/views/sites/search_configuration/_search_field_form.html.erb
@@ -1,5 +1,5 @@
-<div class="form-group card swatch-info search_field" id="search_fields_<%= field_form.index %>">
-	<div class="card-header form-inline">
+<div class="form-group card border-info search_field" id="search_fields_<%= field_form.index %>">
+	<div class="card-header swatch-info form-inline">
 		<div class="card-header"><span class="card-title"><%= field_form.object.new_record? ? 'New' : field_form.object.type.titlecase %> Search</span></div>
 	</div>
 	<div class="card-body" id="search_fields_<%= field_form.index %>_atts">

--- a/lib/dcv/routes.rb
+++ b/lib/dcv/routes.rb
@@ -1,7 +1,7 @@
 module Dcv
   class Routes
-    DOI_ID_CONSTRAINT = { id: /10\.[A-Za-z0-9\-]+\/[^\/]+/ }
-    LEGACY_ID_CONSTRAINT = { id: /(cul|ldpd|donotuse):[^\/]*/ }
+    DOI_ID_CONSTRAINT = { id: /10\.[A-Za-z0-9\-]+\/[^\/\.]+/ }
+    LEGACY_ID_CONSTRAINT = { id: /(cul|ldpd|donotuse):[^\/\.]+/ }
 
     attr_reader :subsite_keys
 

--- a/spec/features/sites/search_configuration_controller_spec.rb
+++ b/spec/features/sites/search_configuration_controller_spec.rb
@@ -8,7 +8,7 @@ describe ::Sites::SearchConfigurationController, type: :feature do
 	let(:site_layout) { import.atts['layout'] }
 	let(:site_link_href) { "/#{site_slug}" }
 	let(:edit_link_href) { "/#{site_slug}/search_configuration/edit" }
-	describe '#update' do
+	describe '#update', js: true do
 		before { import.run }
 		let(:authorized_user) { FactoryBot.create(:user, is_admin: true) }
 		before do
@@ -16,7 +16,7 @@ describe ::Sites::SearchConfigurationController, type: :feature do
 			login_as authorized_user, scope: :user
 			visit(edit_link_href)
 		end
-		it 'updates atts' do
+		it 'updates map atts' do
 			fill_in('Default Latitude', with: "42.0")
 			fill_in('Default Longitude', with: "24.0")
 			click_button "Update Search Configuration"
@@ -25,6 +25,19 @@ describe ::Sites::SearchConfigurationController, type: :feature do
 			visit(edit_link_href)
 			expect(page).to have_field('Default Latitude', with: "42.0")			
 			expect(page).to have_field('Default Longitude', with: "24.0")			
+		end
+		it 'updates facet atts' do
+			expect(find_field('site[search_configuration][facets][0][facet_fields_form_value]').value).to eq("role_test_sim")
+			click_button "Add a facet field"
+			add_block = page.find('#facet_fields_1_atts')
+			add_block.fill_in('site[search_configuration][facets][1][facet_fields_form_value]', with: "level_one_field_sim,level_2_field_sim")
+			add_block.fill_in('site[search_configuration][facets][1][label]', with: "Levels")
+			click_button "Update Search Configuration"
+			# do a find to make sure page loaded
+			find('#facet_fields_1_atts')
+			visit(edit_link_href)
+			expect(find_field('site[search_configuration][facets][1][facet_fields_form_value]').value).to eq("level_one_field_sim,level_2_field_sim")
+			expect(find_field('site[search_configuration][facets][1][label]').value).to eq("Levels")
 		end
 	end
 	describe '#edit' do

--- a/spec/models/site/facet_configuration_spec.rb
+++ b/spec/models/site/facet_configuration_spec.rb
@@ -43,4 +43,11 @@ describe Site::FacetConfiguration do
 			expect(config.eql?(described_class.new(atts.merge(limit: config.limit - 1)))).to be false
 		end
 	end
+	describe '#configure' do
+		let(:blacklight_config) { instance_double(Blacklight::Configuration) }
+		it 'returns false without configuring when field_name is blank' do
+			expect(blacklight_config).not_to receive(:add_facet_field)
+			expect(config.configure(blacklight_config)).to be false
+		end
+	end
 end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -224,4 +224,22 @@ describe Site do
 			end
 		end
 	end
+	describe '#valid?' do
+		let(:site_slug) { 'validators' }
+		it 'is valid with no configuration' do
+			expect(site.valid?).to be true
+		end
+		context 'bad facet configuration' do
+			let(:search_configuration) do
+				base = YAML.load(fixture("yml/sites/search_configuration.yml").read)
+				base['facets'][0]['field_name'] = ""
+				base
+			end
+			it 'is invalid' do
+				site.search_configuration = search_configuration
+				expect(site.valid?).to be false
+				expect(site.errors.details).to have_key(:"search_configuration/facets/field_name")
+			end
+		end
+	end
 end

--- a/spec/routing/catalog_controller_spec.rb
+++ b/spec/routing/catalog_controller_spec.rb
@@ -7,9 +7,11 @@ describe CatalogController, :type => :routing do
     end
     it "routes pid ids to show action" do
       expect(:get => "/catalog/cul:12345").to route_to(controller: "catalog", action:"show", id: "cul:12345")
+      expect(:get => "/catalog/cul:12345.xml").to route_to(controller: "catalog", action:"show", id: "cul:12345", format: 'xml')
     end
     it "routes doi ids to show action" do
       expect(:get => "/catalog/10.123/1a2b-3c4d5e").to route_to(controller: "catalog", action:"show", id: "10.123/1a2b-3c4d5e")
+      expect(:get => "/catalog/10.123/1a2b-3c4d5e.xml").to route_to(controller: "catalog", action:"show", id: "10.123/1a2b-3c4d5e", format: 'xml')
     end
     it "routes citation URLS to citation show action" do
       expect(:get => "/catalog/cul:12345/citation/mla").to route_to(controller: "catalog", action:"show_citation", id: "cul:12345", type: 'mla')


### PR DESCRIPTION
Two fixes addressing bugs with severe impact:
- the move to stronger params mean that a discrepancy in attribute names between the editable site facet configurations and the JSON-persisted model were resulting is error-raising blacklight configurations (DLC-972)
- a greedy regex constraint on ID parameters for DOIs and Fedora PIDs was swallowing the format parameter, resulting in errors/404's when requested (and filling the logs during an IA crawl of the site)