### PR TITLE
DLC-1063: Deployment fixes for resque (plus other related updates)

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -1,7 +1,14 @@
-# default requires
+# Load DSL and set up stages
 require 'capistrano/setup'
+
+# Include default deployment tasks
 require 'capistrano/deploy'
-# additional optional modules used by clio
+
+# Git SCM plugin
+require 'capistrano/scm/git'
+install_plugin Capistrano::SCM::Git
+
+# additional modules
 require 'capistrano/rvm'
 require 'capistrano/bundler'
 require 'capistrano/rails/assets'

--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,7 @@ gem 'loofah', '>= 2.2.1'
 
 group :development, :test do
   # Use Capistrano for deployment
-  gem 'capistrano', '~> 3.14.0', require: false
+  gem 'capistrano', '~> 3.17.3', require: false
   # Rails and Bundler integrations were moved out from Capistrano 3
   gem 'capistrano-rails', '~> 1.4', require: false
   gem 'capistrano-bundler', '~> 1.1', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
-    airbrussh (1.4.2)
+    airbrussh (1.5.0)
       sshkit (>= 1.6.1, != 1.7.0)
     ast (2.4.2)
     bcrypt (3.1.19)
@@ -104,7 +104,7 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     cancancan (3.5.0)
-    capistrano (3.14.1)
+    capistrano (3.17.3)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
@@ -498,7 +498,7 @@ DEPENDENCIES
   blacklight (~> 7.33.1)
   bootsnap (~> 1.9.3)
   cancancan
-  capistrano (~> 3.14.0)
+  capistrano (~> 3.17.3)
   capistrano-bundler (~> 1.1)
   capistrano-passenger (~> 0.2)
   capistrano-rails (~> 1.4)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,4 +1,4 @@
-lock '3.14.1'
+lock '~> 3.17.3'
 
 set :department, 'ldpd'
 set :instance, fetch(:department)
@@ -76,9 +76,14 @@ namespace :deploy do
 
     system("git tag -a #{tag} -m 'auto-tagged' && git push origin --tags")
   end
+end
 
-  after :restart, :clear_cache do
-    on roles(:web), in: :groups, limit: 3, wait: 10 do
+after 'deploy:finished', 'dlc:restart_resque_workers'
+
+namespace :dlc do
+  desc 'Restart the resque workers'
+  task :restart_resque_workers do
+    on roles(:web) do
       within release_path do
         with rails_env: fetch(:rails_env) do
           resque_restart_err_and_out_log = './log/resque_restart_err_and_out.log'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -81,7 +81,12 @@ namespace :deploy do
     on roles(:web), in: :groups, limit: 3, wait: 10 do
       within release_path do
         with rails_env: fetch(:rails_env) do
-          execute :rake, 'resque:restart_workers'
+          resque_restart_err_and_out_log = './log/resque_restart_err_and_out.log'
+          # With Ruby > 3.0, we need to redirect stdout and stderr to a file, otherwise
+          # capistrano hangs on this task (waiting for more output).
+          execute :rake, 'resque:restart_workers', '>', resque_restart_err_and_out_log, '2>&1'
+          # Show the restart log output
+          execute :cat, resque_restart_err_and_out_log
         end
       end
     end

--- a/config/deploy/dev.rb
+++ b/config/deploy/dev.rb
@@ -1,3 +1,3 @@
-server 'all-nginx-dev1.cul.columbia.edu', user: fetch(:remote_user), roles: %w(app db web)
+server 'dlc-rails-dev1.cul.columbia.edu', user: fetch(:remote_user), roles: %w(app db web)
 # Current branch is suggested by default in development
 ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp


### PR DESCRIPTION
Updates include:
- Fix for resque restart
- Updated capistrano gem version
- Address capistrano warning
- Update config/deploy/dev.rb server value