### PR TITLE
DLC-1177 iiif login fails

### DIFF
--- a/app/controllers/concerns/iiif/authz/v2/bytestreams.rb
+++ b/app/controllers/concerns/iiif/authz/v2/bytestreams.rb
@@ -56,8 +56,8 @@ module Iiif::Authz::V2::Bytestreams
     probe_response = Iiif::Authz::V2::ProbeService::Response.new(
       document: @document, bytestream_id: params[:bytestream_id], ability_helper: self, route_helper: self,
       remote_ip: remote_ip, authorization: request.headers['Authorization']).to_h
-    response_status = (probe_response[:status].to_i < 400) ? 200 : probe_response[:status].to_i
-    render json: probe_response, status: response_status
+    # IIIF Auth2 requires probe responses to have HTTP status 200, regardless of effective status in the response
+    render json: probe_response, status: 200
   end
 
   # IIIF Authorization 2.0 Access Service

--- a/app/controllers/concerns/iiif/authz/v2/bytestreams.rb
+++ b/app/controllers/concerns/iiif/authz/v2/bytestreams.rb
@@ -18,14 +18,22 @@ module Iiif::Authz::V2::Bytestreams
       return
     end
 
-   remote_ip = DCV_CONFIG.dig('media_streaming','wowza', 'client_ip_override') || request.remote_ip
-    probe_response = Iiif::Authz::V2::ProbeService::Response.new(document: @document, bytestream_id: params[:bytestream_id],ability_helper: self, route_helper: self, remote_ip: remote_ip).to_h
+    remote_ip = DCV_CONFIG.dig('media_streaming','wowza', 'client_ip_override') || request.remote_ip
+    probe_response = probe_service_response(
+      authorization: nil, bytestream_id: params[:bytestream_id], document: @document, remote_ip: remote_ip
+    ).to_h
     case(probe_response[:status])
     when 302
       redirect_to probe_response[:location]
     else
-      render json: probe_response
+      render nothing: true, status: probe_response[:status]
     end
+  end
+
+  def probe_service_response(bytestream_id:, document:, remote_ip:, authorization: nil)
+    Iiif::Authz::V2::ProbeService::Response.new(
+      document: document, bytestream_id: bytestream_id, ability_helper: self, route_helper: self,
+      remote_ip: remote_ip, authorization: authorization)
   end
 
   # IIIF Authorization 2.0 Probe Service
@@ -53,9 +61,10 @@ module Iiif::Authz::V2::Bytestreams
     end
 
     remote_ip = DCV_CONFIG.dig('media_streaming','wowza', 'client_ip_override') || request.remote_ip
-    probe_response = Iiif::Authz::V2::ProbeService::Response.new(
-      document: @document, bytestream_id: params[:bytestream_id], ability_helper: self, route_helper: self,
-      remote_ip: remote_ip, authorization: request.headers['Authorization']).to_h
+    authorization = request.headers['Authorization']
+    probe_response = probe_service_response(
+      authorization: authorization, bytestream_id: params[:bytestream_id], document: @document, remote_ip: remote_ip
+    ).to_h
     # IIIF Auth2 requires probe responses to have HTTP status 200, regardless of effective status in the response
     render json: probe_response, status: 200
   end

--- a/app/controllers/iiif/access_controller.rb
+++ b/app/controllers/iiif/access_controller.rb
@@ -25,4 +25,8 @@ class Iiif::AccessController < ApplicationController
       format.html { render action: 'login', layout: 'minimal' }
     end
   end
+
+  def subsite_layout
+    Site::LAYOUT_GALLERY
+  end
 end

--- a/app/models/iiif/authz/base_access_token_service.rb
+++ b/app/models/iiif/authz/base_access_token_service.rb
@@ -2,9 +2,11 @@ class Iiif::Authz::BaseAccessTokenService
   attr_reader :id, :canvas, :route_helper
   JWT_HEADER = { alg: 'HS256', typ: 'JWT' }.freeze
 
-  def initialize(canvas, route_helper:, format: nil)
+  def initialize(canvas, route_helper:, format: nil, profile: 'active')
     @canvas = canvas
-    @id = route_helper.bytestream_token_url({catalog_id: canvas.solr_document.id, bytestream_id: 'content', format: format}.compact)
+    id_params = {catalog_id: canvas.solr_document.id, bytestream_id: 'content', format: format}
+    id_params[:profile] = profile unless profile == 'active'
+    @id = route_helper.bytestream_token_url(id_params.compact)
     @route_helper = route_helper
   end
 

--- a/app/models/iiif/authz/v2/external_access_service.rb
+++ b/app/models/iiif/authz/v2/external_access_service.rb
@@ -11,7 +11,7 @@ class Iiif::Authz::V2::ExternalAccessService
   end
 
   def token_service
-    Iiif::Authz::V2::AccessTokenService.new(canvas, route_helper: route_helper).to_h
+    Iiif::Authz::V2::AccessTokenService.new(canvas, route_helper: route_helper, profile: PROFILE).to_h
   end
 
   def to_h

--- a/app/models/iiif/authz/v2/external_access_service.rb
+++ b/app/models/iiif/authz/v2/external_access_service.rb
@@ -16,7 +16,6 @@ class Iiif::Authz::V2::ExternalAccessService
 
   def to_h
     access_service = IIIF_TEMPLATES['v2_access_service'].deep_dup
-    access_service['id'] = 'info:dlc.library.columbia.edu'
     access_service['service'] << token_service
     access_service['profile'] = PROFILE
     access_service['label'] = { 'en' => ["#{I18n.t('blacklight.application_name')} Sessions"] }

--- a/app/models/iiif/authz/v2/local_access_service.rb
+++ b/app/models/iiif/authz/v2/local_access_service.rb
@@ -15,7 +15,7 @@ class Iiif::Authz::V2::LocalAccessService
   end
 
   def token_service
-    Iiif::Authz::V2::AccessTokenService.new(canvas, route_helper: route_helper).to_h
+    Iiif::Authz::V2::AccessTokenService.new(canvas, route_helper: route_helper, profile: @profile).to_h
   end
 
   def to_h

--- a/spec/controllers/concerns/iiif/authz/v2/bytestreams_spec.rb
+++ b/spec/controllers/concerns/iiif/authz/v2/bytestreams_spec.rb
@@ -6,9 +6,11 @@ describe Iiif::Authz::V2::Bytestreams, type: :unit do
       include Iiif::Authz::V2::Bytestreams
     end
   end
+
   subject(:controller) do
     test_class.new
   end
+
   describe '#has_probeable_resource?' do
     let(:bytestream_id) { 'content' }
     let(:params) { { bytestream_id: bytestream_id } }
@@ -56,5 +58,59 @@ describe Iiif::Authz::V2::Bytestreams, type: :unit do
         end
       end
     end
-  end  
+  end
+
+  describe '#resource' do
+    let(:authorization_header) { nil }
+    let(:bytestream_id) { 'content' }
+    let(:bytestream_content_url) { 'bytestream_content_url' }
+    let(:bytestream_probe_url) { 'bytestream_probe_url' }
+    let(:bytestream_token_url) { 'bytestream_token_url' }
+    let(:current_user) { nil }
+    let(:iiif_kiosk_url) { 'iiif_kiosk_url' }
+    let(:iiif_login_url) { 'iiif_login_url' }
+    let(:cache_control) { {} }
+    let(:solr_doc_dc_type) { 'Text' }
+    let(:request_headers) { instance_double(ActionDispatch::Http::Headers) }
+    let(:response_headers) { instance_double(ActionDispatch::Http::Headers) }
+    let(:origin_header) { 'localhost' }
+    let(:params) { { bytestream_id: bytestream_id } }
+    let(:remote_ip) { '0.0.0.0' }
+    let(:request) { instance_double(ActionDispatch::Request, headers: request_headers, remote_ip: remote_ip,
+      host: 'localhost', optional_port: nil, path_parameters: [], protocol: 'http') }
+    let(:response) { instance_double(ActionDispatch::Response, headers: response_headers, cache_control: cache_control) }
+    let(:solr_doc) { SolrDocument.new({
+      id: 'solr-1', dc_type_ssm: [solr_doc_dc_type], title_display_ssm: ['title_display_ssm'],
+      access_control_levels_ssim: [Dcv::AccessLevels::ACCESS_LEVEL_AFFILIATION]
+    }) }
+
+    before do
+      allow(controller).to receive_messages(
+        bytestream_content_url: bytestream_content_url, bytestream_probe_url: bytestream_probe_url, bytestream_token_url: bytestream_token_url,
+        current_user: current_user, fetch: [nil, solr_doc], iiif_kiosk_url: iiif_kiosk_url, iiif_login_url: iiif_login_url,
+        params: params, request: request, response: response, cors_headers: nil
+      )
+      allow(request_headers).to receive(:[]).with('Authorization').and_return(authorization_header)
+      allow(request_headers).to receive(:[]).with('Origin').and_return(origin_header)
+      allow(response_headers).to receive(:[]=).with('Cache-Control', String).and_return(true)
+      allow(response_headers).to receive(:[]=).with('Access-Control-Allow-Origin', origin_header).and_return(origin_header)
+      allow(response_headers).to receive(:[]=).with('Access-Control-Allow-Credentials', String).and_return(true)
+      allow(response_headers).to receive(:[]=).with('Content-Type', String).and_return(true)
+    end
+
+    context 'request is authorized' do
+      it 'redirects to probe response location with 302' do
+        allow(controller).to receive(:can?).and_return(true)
+        expect(controller).to receive(:redirect_to)
+        controller.resource
+      end
+    end
+    context 'request is denied' do
+      it 'responds with nothing and passes 401 through' do
+        allow(controller).to receive(:can?).and_return(false)
+        expect(controller).to receive(:render).with({nothing: true, status: 401})
+        controller.resource
+      end
+    end
+  end
 end

--- a/spec/controllers/concerns/iiif/authz/v2/bytestreams_spec.rb
+++ b/spec/controllers/concerns/iiif/authz/v2/bytestreams_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+describe Iiif::Authz::V2::Bytestreams, type: :unit do
+  let(:test_class) do
+    Class.new(ApplicationController) do
+      include Iiif::Authz::V2::Bytestreams
+    end
+  end
+  subject(:controller) do
+    test_class.new
+  end
+  describe '#has_probeable_resource?' do
+    let(:bytestream_id) { 'content' }
+    let(:params) { { bytestream_id: bytestream_id } }
+
+    before do
+      allow(controller).to receive(:params).and_return(params)      
+    end
+
+    it 'returns false when passed nil' do
+      expect(controller.has_probeable_resource?(nil)).to be false
+    end
+
+    context 'has a SolrDocument' do
+      let(:solr_doc) { instance_double(SolrDocument) }
+      let(:resource_doc) { { id: "fedora/pid/#{bytestream_id}" } }
+
+      context 'with resources' do
+        before do
+          allow(controller).to receive(:resources_for_document).with(solr_doc, false).and_return([resource_doc])
+        end
+
+        it 'works when #resources_for_document returns a present value' do
+          expect(controller.has_probeable_resource?(solr_doc)).to be true
+        end
+      end
+
+      context 'without resources' do
+        let(:dc_type) { 'Software' }
+
+        before do
+          allow(solr_doc).to receive(:fetch).with('dc_type_ssm', []).and_return([dc_type])
+          allow(controller).to receive(:resources_for_document).with(solr_doc, false).and_return([])
+        end
+
+        it 'returns false' do
+          expect(controller.has_probeable_resource?(solr_doc)).to be false
+        end
+
+        context 'but an image dc type' do
+          let(:dc_type) { 'StillImage' }
+          
+          it 'returns true' do
+            expect(controller.has_probeable_resource?(solr_doc)).to be true
+          end
+        end
+      end
+    end
+  end  
+end

--- a/spec/features/iiif/access_controller_spec.rb
+++ b/spec/features/iiif/access_controller_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe Iiif::AccessController, type: :feature do
+  describe "login" do
+    let(:authorized_user) { FactoryBot.create(:user, is_admin: true) }
+
+    before do
+      Warden.test_mode!
+      login_as authorized_user, scope: :user
+      visit "/iiif/3/login"
+    end
+
+    after do
+      Warden.test_reset!
+    end
+
+    it "shows the success message" do
+      expect(page).to have_text('Authentication successful!')
+    end
+  end
+end

--- a/spec/models/iiif/authz/v2/access_token_service_spec.rb
+++ b/spec/models/iiif/authz/v2/access_token_service_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+describe Iiif::Authz::V2::AccessTokenService do
+  subject(:access_token_service) {
+    described_class.new(
+      canvas, route_helper: routes, format: format, profile: profile
+    )
+  }
+  let(:canvas) { instance_double(Iiif::Canvas) }
+  let(:expected_id) { 'expected_id' }
+  let(:format) { nil }
+  let(:routes) { instance_double(ApplicationController) }
+  let(:solr_document_id) { 'solr_document_id' }
+
+  before do
+    allow(canvas).to receive(:solr_document).and_return(SolrDocument.new({id: solr_document_id}))
+    allow(routes).to receive(:bytestream_token_url).with(id_params).and_return(expected_id)
+  end
+
+  context 'profile is external' do
+    let(:profile) { 'external' }
+    let(:id_params) { {catalog_id: solr_document_id, bytestream_id: 'content', profile: profile} }
+
+    it "creates a hashable token service with the expected id" do
+      expect(access_token_service.to_h['id']).to be expected_id
+    end
+  end
+
+  context 'profile is kiosk' do
+    let(:profile) { 'kiosk' }
+    let(:id_params) { {catalog_id: solr_document_id, bytestream_id: 'content', profile: profile} }
+
+    it "creates a hashable token service with the expected id" do
+      expect(access_token_service.to_h['id']).to be expected_id
+    end
+  end
+
+  context 'profile is active' do
+    let(:profile) { 'active' }
+    # active profile should not include additional query params to distinguish it
+    let(:id_params) { {catalog_id: solr_document_id, bytestream_id: 'content'} }
+
+    it "creates a hashable token service with the expected id" do
+      expect(access_token_service.to_h['id']).to be expected_id
+    end
+  end
+end


### PR DESCRIPTION
This is the bug that was revealed during the ACFA v2 deploy. This PR adds a feature spec for rendering the authentication frame content, and fixes the bug. I also noticed that a spec from an earlier issue had not been committed; it is added in a separate commit.