### PR TITLE
DLC-1183: DLC should handle media access copy URIs that start with file:/// (in addition to file:/)

### DIFF
--- a/app/helpers/dcv/media_element_helper.rb
+++ b/app/helpers/dcv/media_element_helper.rb
@@ -1,7 +1,9 @@
 module Dcv::MediaElementHelper
   # render a video streaming player with a non-token protected src
   def render_media_element_streaming_video_player(wowza_project, video_path, poster_path, captions_path: nil, width:1024, height:576, logo_path: nil, **args)
-    url = "https://diglib-wowza-prod1.cul.columbia.edu:8443/#{wowza_project}/_definst_/mp4:#{video_path}/playlist.m3u8"
+    wowza_config = DCV_CONFIG.dig(:media_streaming,:wowza)
+    return unless wowza_config
+    url = "https://#{wowza_config[:host]}:#{wowza_config[:ssl_port]}/#{wowza_project}/_definst_/mp4:#{video_path}/playlist.m3u8"
     render_media_element_streaming_player(url, poster_path, captions_path: captions_path, width: width, height: height)
   end
 

--- a/app/helpers/dcv/media_element_helper.rb
+++ b/app/helpers/dcv/media_element_helper.rb
@@ -1,7 +1,7 @@
 module Dcv::MediaElementHelper
   # render a video streaming player with a non-token protected src
   def render_media_element_streaming_video_player(wowza_project, video_path, poster_path, captions_path: nil, width:1024, height:576, logo_path: nil, **args)
-    url = "https://firehose.cul.columbia.edu:8443/#{wowza_project}/_definst_/mp4:#{video_path}/playlist.m3u8"
+    url = "https://diglib-wowza-prod1.cul.columbia.edu:8443/#{wowza_project}/_definst_/mp4:#{video_path}/playlist.m3u8"
     render_media_element_streaming_player(url, poster_path, captions_path: captions_path, width: width, height: height)
   end
 

--- a/lib/dcv/utils/cdn_utils.rb
+++ b/lib/dcv/utils/cdn_utils.rb
@@ -51,12 +51,16 @@ module Dcv::Utils::CdnUtils
     ds_profile = object_profile.dig("datastreams","access")
     return nil if ds_profile.blank?
     ds_location = ds_profile["dsLocation"]
-    ds_location.present? ? Addressable::URI.unencode(ds_location).gsub(/^file:\/+/, '/') : nil
+    ds_location.present? ? file_uri_ds_location_to_file_path(ds_location) : nil
   end
 
   def self.wowza_access_copy_location_from_fcrepo(asset_doc)
     asset_pid = asset_doc[:pid] || asset_doc[:id]
     ds = Cul::Hydra::Fedora.ds_for_opts({pid: asset_pid, dsid: 'access'})
-    ds.present? ? Addressable::URI.unencode(ds.dsLocation).gsub(/^file:\/+/, '/') : ''
+    ds.present? ? file_uri_ds_location_to_file_path(ds.dsLocation) : ''
+  end
+
+  def self.file_uri_ds_location_to_file_path(file_uri_ds_location)
+    Addressable::URI.unencode(file_uri_ds_location).gsub(/^file:\/+/, '/')
   end
 end

--- a/lib/dcv/utils/cdn_utils.rb
+++ b/lib/dcv/utils/cdn_utils.rb
@@ -51,12 +51,12 @@ module Dcv::Utils::CdnUtils
     ds_profile = object_profile.dig("datastreams","access")
     return nil if ds_profile.blank?
     ds_location = ds_profile["dsLocation"]
-    ds_location.present? ? Addressable::URI.unencode(ds_location).gsub(/^file:/, '') : nil
+    ds_location.present? ? Addressable::URI.unencode(ds_location).gsub(/^file:\/+/, '/') : nil
   end
 
   def self.wowza_access_copy_location_from_fcrepo(asset_doc)
     asset_pid = asset_doc[:pid] || asset_doc[:id]
     ds = Cul::Hydra::Fedora.ds_for_opts({pid: asset_pid, dsid: 'access'})
-    ds.present? ? Addressable::URI.unencode(ds.dsLocation).gsub(/^file:/, '') : ''
+    ds.present? ? Addressable::URI.unencode(ds.dsLocation).gsub(/^file:\/+/, '/') : ''
   end
 end

--- a/spec/unit/dcv/utils/cdn_utils_spec.rb
+++ b/spec/unit/dcv/utils/cdn_utils_spec.rb
@@ -6,6 +6,7 @@ describe Dcv::Utils::CdnUtils, type: :unit do
     let(:url_encoded_file_path) { file_path.gsub(' ', '%20').gsub('&', '%26') }
     let(:single_slash_file_uri) { "file:#{url_encoded_file_path}" }
     let(:triple_slash_file_uri) { "file://#{url_encoded_file_path}" }
+
     it 'properly converts a ds location that uses a single slash file URI' do
       expect(described_class.file_uri_ds_location_to_file_path(single_slash_file_uri)).to eq(file_path)
     end

--- a/spec/unit/dcv/utils/cdn_utils_spec.rb
+++ b/spec/unit/dcv/utils/cdn_utils_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe Dcv::Utils::CdnUtils, type: :unit do
+  describe '.file_uri_ds_location_to_file_path' do
+    let(:file_path) { '/path/to/a & b.mp4' }
+    let(:url_encoded_file_path) { file_path.gsub(' ', '%20').gsub('&', '%26') }
+    let(:single_slash_file_uri) { "file:#{url_encoded_file_path}" }
+    let(:triple_slash_file_uri) { "file://#{url_encoded_file_path}" }
+    it 'properly converts a ds location that uses a single slash file URI' do
+      expect(described_class.file_uri_ds_location_to_file_path(single_slash_file_uri)).to eq(file_path)
+    end
+
+    it 'properly converts a ds location that uses a triple slash file URI' do
+      expect(described_class.file_uri_ds_location_to_file_path(triple_slash_file_uri)).to eq(file_path)
+    end
+  end
+end


### PR DESCRIPTION
Creating this as a draft for now.  Will add tests soon.