### PR TITLE
shim missing polymorphic URL helper used by Blacklight index.json builder

### DIFF
--- a/app/helpers/dcv/dcv_url_helper.rb
+++ b/app/helpers/dcv/dcv_url_helper.rb
@@ -120,4 +120,10 @@ module Dcv::DcvUrlHelper
   def solr_document_url(solr_document, options = {})
     search_state.url_for_document(solr_document, options)
   end
+
+# solr_document routing patch because upstream JSON builder uses polymorphic URL in BL7
+  def show_solr_document_url(solr_document, options = {})
+    url_attrs = solr_document_url(solr_document, options)
+    url_attrs.is_a?(Hash) ? url_for(url_attrs) : url_attrs
+  end
 end


### PR DESCRIPTION
see also DLC-1186 in JIRA

@elohanlon this is the bug that surfaced while we were walking through data requests.

Upstream blacklight uses [polymorphic_url](https://api.rubyonrails.org/classes/ActionDispatch/Routing/PolymorphicRoutes.html#method-i-polymorphic_url) to build the document links in its [JSON responses](https://github.com/projectblacklight/blacklight/blob/v7.33.1/app/views/catalog/index.json.jbuilder). This relies on a route inserted by an [install generator](https://github.com/projectblacklight/blacklight/blob/v7.33.1/lib/generators/blacklight/models_generator.rb#L34-L36). That logic presumes that there is a single route (to the catalog controller), but we have many contextual routes.

The two options I can see for addressing this are:
1. Override  `app/views/catalog/index.json.builder`. This is obviously more code; it also would mean keeping a shared view in this repository in `app/views/catalog`, a legacy fallback we have been trying to avoid. Also I prefer to minimize overriding views - I think of them as private API.
2. Shim the routing method that would be created by the route configuration (if we used it). This is ugly, but preserves the ability to build contextual routes and I think minimizes the amount of local code we need to exercise in rspec.

This PR adopts the second approach. The controller spec for the change calls `render_views` - I would usually want to avoid that and separately test the view, but in this case the view is entirely upstream code (and tested there).