### PR TITLE
[DLC-1294] remove unused assets

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -5,8 +5,6 @@
     <script type="module" crossorigin src="https://toolkit.library.columbia.edu/v5/assets/main.js"></script>
     <link rel="stylesheet" crossorigin href="https://toolkit.library.columbia.edu/v5/assets/main.css">
     <%= vite_client_tag %>
-    <%= vite_typescript_tag 'prime2025.js' %>
-    <%= vite_stylesheet_tag 'prime2025.scss' %>
     <style>
       <%
         # TODO: Move style below to a better place, and don't reference blogs url.


### PR DESCRIPTION
### [Jira Ticket](https://columbiauniversitylibraries.atlassian.net/jira/software/c/projects/DLC/issues?jql=project%20%3D%20DLC%20ORDER%20BY%20created%20DESC&selectedIssue=DLC-1294)
***

This PR removes two unused vite asset tags that were causing an error when rendering the admin layout.

This will enable work for the import/export feature