### PR TITLE
[DLC-1136] Remove zero padding on portrait home view

### DIFF
--- a/app/views/portrait/home.html.erb
+++ b/app/views/portrait/home.html.erb
@@ -15,7 +15,7 @@
 								<%- end -%>
 							</div>
 							<%- cache [@subsite, @page] do -%>
-								<div class="col-xs-12 col-sm-6 pl-0">
+								<div class="col-xs-12 col-sm-6">
 									<%- @page.site_text_blocks.sort { |a,b| a.sort_label <=> b.sort_label }.each do |text_block| -%>
 										<%- if text_block.label.present? -%>
 											<h2 class="h5 text-uppercase"><%= text_block.label %></h2>


### PR DESCRIPTION
### [Jira Ticket](https://columbiauniversitylibraries.atlassian.net/browse/DLC-1136)
***

This PR removes the 'pl-0' bootstrap class from the containing div for descriptive text and buttons on the portrait layout home page view.

'pl-0' adds 'padding-left: 0px' on this element, causing things to look off. Removing the class has the element use 15px of padding and it looks a lot better.

With the change:
<img width="883" height="633" alt="image" src="https://github.com/user-attachments/assets/5a04595d-4197-41b1-953d-fb19464c2af9" />
