### PR TITLE
permit FOLIO BIBs for linkable finding aids (DLC-1300)

### DIFF
--- a/app/helpers/field_display_helpers/archival_context.rb
+++ b/app/helpers/field_display_helpers/archival_context.rb
@@ -1,16 +1,13 @@
 module FieldDisplayHelpers::ArchivalContext
   def has_archival_context?(field_config, document)
-    json_src = document.fetch(field_config.archival_context_field || field_config.field,'{}')
-    JSON.load(json_src).detect {|ac| ac['dc:coverage'].present? }
+    SolrDocument.wrap(document).has_archival_context?(field_config.archival_context_field || field_config.field)
   end
 
   def display_archival_context(args={})
-    contexts = Array(args.fetch(:value,'[]')).map { |json_values| JSON.load(json_values).map {|json| ::ArchivalContext.new(json) } }
-    contexts.flatten!
     shelf_locator = field_helper_shelf_locator_value(args) if args.fetch(:shelf_locator, true)
     document = args[:document]
     aspace_ids = document&.fetch(FieldDisplayHelpers::ASPACE_PARENT_FIELD, nil)
-    contexts.map do |context|
+    document.archival_contexts.map do |context|
       context.aspace_id = aspace_ids&.first
       title = context.titles(link: args.fetch(:link, true)).first.dup
       title << '. ' << shelf_locator if shelf_locator && title.present?
@@ -34,17 +31,18 @@ module FieldDisplayHelpers::ArchivalContext
   def display_collection_with_links(args={})
     values = Array(args[:value])
     document = args[:document]
-    if document['archival_context_json_ss']
-      json = JSON.load(document['archival_context_json_ss'])
+    if document.has_archival_context? || document.has_collection_bib_links?
+      json = document.archival_context_json
       values.map do |value|
         collection = json.detect { |context| context['dc:title'].to_s.strip == value.strip }
         if collection
           clio = collection.fetch('dc:bibliographicCitation',{})['@id']
           if clio
             bib_id = clio.split('/')[-1].to_s
-            if bib_id =~ /^\d+$/
+            # Voyager BIBs will be all numeric; FOLIO BIBs will be prefixed for 'instance'
+            if bib_id =~ /^(in)?\d+$/
               clio_only = collection.fetch('dc:coverage', []).blank?
-              fa_url = generate_finding_aid_url(bib_id, document, clio_only: clio_only)
+              fa_url = document.finding_aid_url(bib_id, clio_only: clio_only)
               value = link_to(value, fa_url) if fa_url
             end
           end
@@ -52,24 +50,17 @@ module FieldDisplayHelpers::ArchivalContext
         value.html_safe
       end
     else
-      args[:value]
+      values
     end
   end
 
   def has_collection_bib_links?(field_config, document)
-    if document['archival_context_json_ss']
-      JSON.load(document['archival_context_json_ss']).detect do |collection|
-        collection['dc:bibliographicCitation']
-      end
-    end
+    document.has_collection_bib_links?
   end
 
   def display_collection_bib_links(args={})
     document = args[:document]
-    JSON.load(document['archival_context_json_ss']).select do |collection|
-      collection['dc:bibliographicCitation']
-    end.map do |collection|
-      clio = collection.fetch('dc:bibliographicCitation',{})['@id']
+    document.collection_bib_links.map do |clio|
       link_to(clio, clio) if clio
     end
   end

--- a/app/helpers/field_display_helpers/repository.rb
+++ b/app/helpers/field_display_helpers/repository.rb
@@ -1,34 +1,7 @@
 module FieldDisplayHelpers::Repository
   def field_helper_repo_code_value(args = {})
-    document = args.fetch(:document, {}).to_h.with_indifferent_access
-    return unless document.present?
-    document['repo_code_lookup'] ||= begin
-      repo_code = document['lib_repo_code_ssim']&.first
-      repo_fields = ['lib_repo_full_ssim', 'lib_repo_short_ssim']
-      repo_fields.detect do |field|
-        unless document[field].blank?
-          codes = code_map_for_repo_field(field)
-          document[field].detect do |repo_value|
-            repo_code ||= codes[repo_value]
-          end
-        end
-      end
-      repo_code
-    end
-  end
-
-  def generate_finding_aid_url(bib_id, document, clio_only: false, deep_link: false)
-    repo_code = field_helper_repo_code_value(document: document)
-    repo_slug = t("cul.archives.arclight_slug.#{repo_code.downcase.sub('-', '')}") if repo_code
-    if repo_slug.present? && bib_id && !clio_only
-      finding_aid_url = "https://findingaids.library.columbia.edu/archives/cul-#{bib_id}"
-      if deep_link && document[FieldDisplayHelpers::ASPACE_PARENT_FIELD].present?
-        return "#{finding_aid_url}_aspace_#{Array(document[FieldDisplayHelpers::ASPACE_PARENT_FIELD]).first}"
-      end
-      finding_aid_url
-    else
-      "https://clio.columbia.edu/catalog/#{bib_id}" if bib_id
-    end
+    document = SolrDocument.wrap(args.fetch(:document, {}))
+    document.repository_code
   end
 
   # Link to a translated lib_repo_short_ssim value
@@ -115,10 +88,6 @@ module FieldDisplayHelpers::Repository
       message << " Contact #{link_to(email_display, "mailto:#{email_display}")}."
     end
     message.html_safe
-  end
-
-  def code_map_for_repo_field(field)
-    ActiveSupport::HashWithIndifferentAccess.new(I18n.t('ldpd.' + field.split('_')[-2] + '.repo').invert)
   end
 
   def get_short_repo_names_to_full_repo_names

--- a/app/models/concerns/solr_document/archival_context.rb
+++ b/app/models/concerns/solr_document/archival_context.rb
@@ -1,0 +1,79 @@
+module SolrDocument::ArchivalContext
+	extend ActiveSupport::Concern
+
+	def archival_context_json(archival_context_field = nil)
+		archival_context_field ||= FieldDisplayHelpers::ARCHIVAL_CONTEXT_JSON_FIELD
+		@archival_context_jsons ||= {}
+		@archival_context_jsons[archival_context_field] ||= begin
+			json_srcs = Array.wrap(self.fetch(archival_context_field,'[]'))
+			json_srcs.map { |json_src| JSON.load(json_src) }.flatten
+		end
+	end
+
+	def has_archival_context?(archival_context_field = nil)
+		archival_context_json(archival_context_field).detect {|ac| ac['dc:coverage'].present? }
+	end
+
+	def archival_contexts(archival_context_field = nil)
+		archival_context_field ||= FieldDisplayHelpers::ARCHIVAL_CONTEXT_JSON_FIELD
+		@archival_contexts ||= {}
+		@archival_contexts[archival_context_field] ||= begin
+			archival_context_json(archival_context_field).map do |ac_json|
+				::ArchivalContext.new(ac_json)
+			end
+		end
+	end
+
+	def has_collection_bib_links?(archival_context_field = nil)
+		archival_context_field ||= FieldDisplayHelpers::ARCHIVAL_CONTEXT_JSON_FIELD
+		archival_context_json(archival_context_field).detect do |collection|
+			collection.dig('dc:bibliographicCitation', '@id')
+		end
+	end
+
+	def collection_bib_links(archival_context_field = nil)
+		archival_context_field ||= FieldDisplayHelpers::ARCHIVAL_CONTEXT_JSON_FIELD
+		archival_context_json(archival_context_field).map do |collection|
+			collection.dig('dc:bibliographicCitation', '@id')
+		end.compact
+	end
+
+	def repository_code
+		@repo_code_lookup ||= begin
+			repo_code = self['lib_repo_code_ssim']&.first
+			repo_fields = ['lib_repo_full_ssim', 'lib_repo_short_ssim']
+			repo_fields.each do |field|
+				unless repo_code || self[field].blank?
+					codes = code_map_for_repo_field(field)
+					self[field].each do |repo_value|
+						repo_code ||= codes[repo_value]
+					end
+				end
+			end
+			repo_code
+		end
+	end
+
+	def finding_aid_url(bib_id, clio_only: false, deep_link: false)
+		return unless self['collection_key_ssim']&.include?(bib_id)
+
+		repo_code = self.repository_code
+		repo_slug = I18n.t("cul.archives.arclight_slug.#{repo_code.downcase.sub('-', '')}") if repo_code
+		try_finding_aid = repo_slug.present? || self.has_archival_context?
+		if try_finding_aid && bib_id && !clio_only
+			finding_aid_url = "https://findingaids.library.columbia.edu/archives/cul-#{bib_id}"
+			if deep_link && self[FieldDisplayHelpers::ASPACE_PARENT_FIELD].present?
+				return "#{finding_aid_url}_aspace_#{Array(self[FieldDisplayHelpers::ASPACE_PARENT_FIELD]).first}"
+			end
+			finding_aid_url
+		else
+			"https://clio.columbia.edu/catalog/#{bib_id}" if bib_id
+		end
+	end
+
+	private
+
+	def code_map_for_repo_field(field)
+		ActiveSupport::HashWithIndifferentAccess.new(I18n.t('ldpd.' + field.split('_')[-2] + '.repo').invert)
+	end
+end

--- a/app/models/iiif/base_resource.rb
+++ b/app/models/iiif/base_resource.rb
@@ -1,7 +1,7 @@
 class Iiif::BaseResource
   extend Forwardable
   def_delegator 'I18n', :t
-  include FieldDisplayHelpers::Repository
+
   attr_reader :id, :solr_document
 
   IIIF_CONTEXTS = [
@@ -68,11 +68,11 @@ class Iiif::BaseResource
   def archival_collection
     @archival_collection ||= begin
       value_obj = {}
-      bib_ids = @solr_document[:collection_key_ssim]&.select {|bib_val| bib_val =~ /^\d+$/ }
+      bib_ids = @solr_document[:collection_key_ssim]&.select {|bib_val| bib_val =~ /^(in)?\d+$/ }
       if bib_ids.present?
         value_obj[:seeAlso] = bib_ids.map do |bib_id|
           {
-            id: generate_finding_aid_url(bib_id, @solr_document, deep_link: true),
+            id: @solr_document.finding_aid_url(bib_id, deep_link: true),
             profile: 'https://clio.columbia.edu/archives',
           }
         end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -15,6 +15,7 @@ class SolrDocument
   RESOURCE_MODEL = 'GenericResource'
 
   include Blacklight::Solr::Document
+  include SolrDocument::ArchivalContext
   include SolrDocument::CleanResolver
   include SolrDocument::FieldSemantics
   include SolrDocument::PublicationInfo
@@ -150,5 +151,16 @@ class SolrDocument
     res = rsolr.send_and_receive('select', params: solr_params.to_hash, method: :get)
     solr_response = Blacklight::Solr::Response.new(res, solr_params, solr_document_model: self)
     solr_response['response']['docs'].each {|doc| block.yield new(doc)}
+  end
+
+  # modeled after ActiveSupport's Array#wrap
+  def self.wrap(obj)
+    if obj.is_a?(SolrDocument)
+      obj
+    elsif obj.respond_to? :to_h
+      SolrDocument.new(obj.to_h)
+    else
+      SolrDocument.new()
+    end
   end
 end

--- a/app/overrides/deprecation_override.rb
+++ b/app/overrides/deprecation_override.rb
@@ -1,0 +1,6 @@
+module Deprecation
+  # Declare that a method has been deprecated.
+  def self.deprecate_methods(target_module, *method_names)
+    method_names.each { |method_name| Rails.logger.info("ignoring deprecation redefines on #{target_module}.#{method_name}") }
+  end
+end

--- a/spec/fixtures/mods/mods-archival-context.xml
+++ b/spec/fixtures/mods/mods-archival-context.xml
@@ -3,6 +3,10 @@
   <mods:titleInfo>
     <mods:title>Agreement between Gunnar Myrdal and Harper &amp; Brothers for the publication of "An American Dilemma," January 8, 1943</mods:title>
   </mods:titleInfo>
+  <mods:location>
+    <mods:physicalLocation authority='marcorg'>NNC-RB</mods:physicalLocation>
+    <mods:physicalLocation>RBML</mods:physicalLocation>
+  </mods:location>
   <mods:relatedItem type="host" displayLabel="Project">
     <mods:titleInfo>
       <mods:title>Carnegie Digital Past and Future</mods:title>

--- a/spec/fixtures/mods/mods-aspace-ids.xml
+++ b/spec/fixtures/mods/mods-aspace-ids.xml
@@ -12,7 +12,7 @@
     <titleInfo valueURI="http://id.library.columbia.edu/term/2069ef6d-f83d-4925-a27a-2bf6507193df">
       <title>Italian Jewish Community Regulations</title>
     </titleInfo>
-    <identifier type="CLIO">11520374</identifier>
+    <identifier type="CLIO">in11520374</identifier>
     <part>
       <detail>
         <title type="series" level="1">Series I: Ferrara (Italy)</title>

--- a/spec/helpers/field_display_helpers/archival_context_spec.rb
+++ b/spec/helpers/field_display_helpers/archival_context_spec.rb
@@ -12,49 +12,84 @@ require 'rails_helper'
 # end
 
 describe FieldDisplayHelpers::ArchivalContext, :type => :helper do
-  let(:json_src) { fixture('json/archival_context.json').read }
-  let(:json) { JSON.load(json_src) }
+  let(:xml_src) { fixture(File.join("mods", "mods-archival-context.xml")) }
+  let(:ng_xml) { Nokogiri::XML(xml_src.read) }
+  let(:adapter) { Dcv::Solr::DocumentAdapter::ModsXml.new(ng_xml) }
+  let(:solr_data) { adapter.to_solr }
   let(:field_config) { instance_double(Blacklight::Configuration::Field) }
   include_context "a solr document"
+
   describe "#display_collection_with_links" do
     let(:value) { 'Carnegie Corporation of New York Records' }
-    let(:solr_data) {
-      {
-        id: document_id, archival_context_json_ss: JSON.generate([json]), lib_repo_code_ssim: 'nnc'
-      }
-    }
+    let(:solr_data) { adapter.to_solr.merge({ id: document_id }) }
     subject(:display) { helper.display_collection_with_links(document: solr_document, value: value).first }
+
     context 'collection has a bib id' do
-      it 'links to the finding aid' do
-        expect(display).to match(/finding/)
-      end
-      context 'collection has no further archival context' do
-        before do
-          json["dc:coverage"] = []
+      context 'and it has a repo code and archival context' do
+        it 'links to the finding aid' do
+          expect(display).to match(/finding/)
         end
+      end
+
+      context 'with an instance prefix' do
+        let(:xml_src) { fixture(File.join("mods", "mods-aspace-ids.xml")) }
+        let(:value) { 'Italian Jewish Community Regulations' }
+
+        it 'links to the finding aid' do
+          expect(display).to match(/finding/)
+        end
+      end
+
+      context 'and it has further archival context but no repo code' do
+        before do
+          # delete the repo code data and the titles used to try to backfill it
+          solr_data.delete("lib_repo_code_ssim")
+          solr_data.delete("lib_repo_full_ssim")
+          solr_data.delete("lib_repo_short_ssim")
+        end
+
+        it 'links to the finding aid' do
+          expect(display).to match(/finding/)
+        end
+      end
+
+      context 'and it has no further archival context' do
+        before do
+          json = JSON.load(solr_data["archival_context_json_ss"])
+          json.first["dc:coverage"] = []
+          solr_data["archival_context_json_ss"] = JSON.generate(json)
+        end
+
         it 'links to clio' do
           expect(display).to match(/clio/)
         end
       end
     end
+
     context 'collection has no bib id' do
       before do
-        json["dc:bibliographicCitation"]["@id"] = 'https://server.columbia.edu/catalog'
+        json = JSON.load(solr_data["archival_context_json_ss"])
+        json.first["dc:bibliographicCitation"]["@id"] = 'https://server.columbia.edu/catalog'
+        solr_data["archival_context_json_ss"] = JSON.generate(json)
       end
+
       it 'links when the collection has a bib id' do
         expect(display).to eql value
       end
     end
   end
+
+  # this helper produces a composed label of collection and archival context with no links.
+  # it is used in index views.
   describe "#display_composite_archival_context" do
     let(:xml_src) { fixture(File.join("mods", "mods-aspace-ids.xml")) }
-    let(:ng_xml) { Nokogiri::XML(xml_src.read) }
-    let(:adapter) { Dcv::Solr::DocumentAdapter::ModsXml.new(ng_xml) }
     let(:solr_data) { adapter.to_solr }
     let(:collection_value) { ["Italian Jewish Community Regulations"] }
     let(:expected) { "Italian Jewish Community Regulations. Series I: Ferrara (Italy). Subseries I.D Noise Regulations" }
+
     it 'builds values without modifying the solr document over multiple calls' do
       args = {document: solr_document, value: collection_value, shelf_locator: false}
+      # see also DLC-1194
       expect(helper.display_composite_archival_context(**args).first).to eql expected
       expect(helper.display_composite_archival_context(**args).first).to eql expected
       expect(helper.display_composite_archival_context(**args).first).to eql expected

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -110,4 +110,16 @@ describe SolrDocument do
       expect(solr_document.has_structure?).to be false
     end
   end
+  describe '.wrap' do
+    it 'returns the arg if it is a SolrDocument' do
+      expect(SolrDocument.wrap(solr_document)).to be(solr_document)
+    end
+    it 'return a SolrDocument if it is a hash' do
+      expect(SolrDocument.wrap(solr_document.to_h)).to be_a(SolrDocument)
+    end
+    it 'return a blank SolrDocument if it is an unknown object' do
+      expect(SolrDocument.wrap(true)).to be_a(SolrDocument)
+      expect(SolrDocument.wrap(true).to_h).to be_blank
+    end
+  end
 end


### PR DESCRIPTION
- do not require a repository code if there is archival context
- refactor some helper methods into SolrDocument methods for reusability and clarity of codebase
- add SolrDocument.wrap to guarantee SolrDocument in contexts where a hash is possible