### PR TITLE
[DLC-1303] Fix illegible title for non-home pages

### DIFF
--- a/app/javascript/stylesheets/portrait/base.scss
+++ b/app/javascript/stylesheets/portrait/base.scss
@@ -5,6 +5,15 @@
 	border-color: map-get($theme-border-colors, 'body');
 }
 
+.home {
+  #site-banner {
+    #site-title {
+      color: white;
+      text-shadow: 1px 1px black;
+    }
+  }
+}
+
 #site-banner {
 	color: map-get($theme-text-colors, 'brand');
 	background-color: map-get($theme-colors, 'brand');
@@ -21,8 +30,7 @@
 		text-transform: uppercase;
 		font-family: $font_b;
 		font-weight: 300;
-		color: white;
-    text-shadow: 1px 1px black;
+    color: black;
 		white-space: normal;
 	}
 	#site-banner-subtitle {

--- a/app/javascript/stylesheets/signature/base.scss
+++ b/app/javascript/stylesheets/signature/base.scss
@@ -92,6 +92,15 @@ header[role='banner'] {
 	}
 }
 
+.home {
+  #site-banner {
+    #site-title {
+      color: white;
+      text-shadow: 1px 1px black;
+    }
+  }
+}
+
 #site-title {
 	width:100%;
 	padding-top: 4px;
@@ -101,11 +110,10 @@ header[role='banner'] {
 	font-size: 198%;
 	font-weight: 200;
 	line-height: 1.1;
-	color: white;
+	color: black;
 	text-align: center;
 	text-decoration: none;
 	text-transform: uppercase;
-	text-shadow: 1px 1px black;
 	vertical-align: bottom;
 	.dr-arrow {
 		color: lighten(map-get($theme-border-colors, 'secondary'),35%);


### PR DESCRIPTION
### [Jira Ticket](http://columbiauniversitylibraries.atlassian.net/browse/DLC-1303?search_id=392a8bea-f548-4fcf-8794-31be0e559963)
***
Non-home pages for sites using the blue/default palette were hard to read due to the drop shadow effect that was added in a recent deployment. This PR addresses this by having non-home pages render the site-title element as just black text.

Now it looks like:
<img width="1234" height="672" alt="image" src="https://github.com/user-attachments/assets/b70fb1eb-ae01-48c8-93df-32171606a5a7" />
