### PR TITLE
Bugfix/1304

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ '*' ]
+    branches: [ '**' ]
 
 jobs:
   ci-rails-app:

--- a/app/javascript/src/features/sites/edit.js
+++ b/app/javascript/src/features/sites/edit.js
@@ -311,22 +311,26 @@ function addTooltips(selection) {
  * ON READY *
  ************/
 export function onReady() {
-	const $siteNavigation = $(".site_navigation");
-	if ($siteNavigation.length == 0) { return; }
-	// make nav groups container sortable
-	$(".site_navigation").sortable({
-		'items': '.site_navigation_menu',
-		'containment': 'parent',
-		'axis': 'y',
-		'handle': '.site_navigation_menu_handle',
-		'cursor': 'move',
-		'opacity': 1.0,
-		'update': navMenuPositionUpdated
-	});
-	// make each nav group sortable
-	sortableLinks($(".site_navigation_links"));
-	// make each text block sortable
-	sortableTextBlocks($(".site_text_blocks"));
-	addMarkdownEditors($(".site_text_blocks"));
-	addTooltips($("form"));
+  const $siteNavigation = $(".site_navigation");
+  const $siteTextBlocks = $(".site_text_blocks");
+  if ($siteTextBlocks.length > 0) {
+    // make each text block sortable
+    sortableTextBlocks($(".site_text_blocks"));
+    addMarkdownEditors($(".site_text_blocks"));
+  }
+  if ($siteNavigation.length > 0) {
+    // make nav groups container sortable
+    $(".site_navigation").sortable({
+      items: ".site_navigation_menu",
+      containment: "parent",
+      axis: "y",
+      handle: ".site_navigation_menu_handle",
+      cursor: "move",
+      opacity: 1.0,
+      update: navMenuPositionUpdated,
+    });
+    // make each nav group sortable
+    sortableLinks($(".site_navigation_links"));
+  }
+  addTooltips($("form"));
 };

--- a/spec/features/sites/pages_controller_spec.rb
+++ b/spec/features/sites/pages_controller_spec.rb
@@ -83,7 +83,8 @@ describe ::Sites::PagesController, type: :feature do
 			find('#site-page-add-block').click
 			find('button[data-target="#site_page_text_block_1_markdown"]').click # Show Text Block content
 			find('#site_page_site_text_blocks_attributes_1_label').set("Text Block Value")
-			fill_in 'site_page_site_text_blocks_attributes_1_markdown', with: '**Text Block Value**'
+			# sending key events is complicated; we will fake it with the editor's JS api
+			page.execute_script("document.querySelector('#site_page_text_block_1_markdown .CodeMirror').CodeMirror.setValue('**Text Block Value**');")
 			# remove the first block - the second should be all that is left
 			find('#site_text_block_0 .remove').click
 			click_button "Update Page"


### PR DESCRIPTION
### [Jira Ticket](https://columbiauniversitylibraries.atlassian.net/browse/DLC-1304)

### **This should also fix [DLC-1305](https://columbiauniversitylibraries.atlassian.net/browse/DLC-1305)**
***
Fixes the bug with markdown editor not being rendered when trying to edit existing site page text blocks.

Because there are no nav links in the DOM when it the `onReady` function fires on the page edit view, the function was returning before it called `addMarkdownEditors()` on the site_text_block elements (which attaches the EasyMD editor to the textarea for each textBlock). `addMarkdownEditors()` is called explicitly when you click the ‘add text block’ button, hence it was being rendered for new text blocks.

This PR changes `onReady` to call methods based on which elements are present in the DOM when it runs.

A unit test also had to be updated: it appears the textarea element is not visible in the normal DOM when the markdown editor is attached to it, so `fill_in` couldn't be used to set its value. I reverted to the previous version of that line and the test was able to pass.

One last change in this PR: I edited the `ci.yml` file's glob pattern so that branches with '/'s in them will run the ci workflow (like this one).