### PR TITLE
Webhelp 335 dlc image card api

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.1.7']
+        ruby-version: ['3.3.8']
         node: ['22']
     env:
       RAILS_ENV: test

--- a/app/controllers/api/v1/external_display_controller.rb
+++ b/app/controllers/api/v1/external_display_controller.rb
@@ -1,0 +1,51 @@
+module Api
+  module V1
+    class ExternalDisplayController < ApplicationController
+      rescue_from ActionController::ParameterMissing, with: :handle_parameter_missing
+
+      def info
+        result = Api::InfoService.new(
+          item_id,
+          asset_id
+        ).call
+
+        if result.success?
+          render json: result.data, status: result.status
+        else
+          render_error(
+            code: result.error_code,
+            message: result.error_message,
+            status: result.status
+          )
+        end
+      end
+
+      private
+
+      def item_id
+        params.require(:itemId)
+      end
+
+      def asset_id
+        params.require(:assetId)
+      end
+
+      def render_error(code:, message:, status:)
+        render json: {
+          error: {
+            code: code,
+            message: message
+          }
+        }, status: status
+      end
+
+      def handle_parameter_missing(exception)
+        render_error(
+          code: 'missing_parameter',
+          message: exception.message,
+          status: :bad_request
+        )
+      end
+    end
+  end
+end

--- a/app/services/api/info_service.rb
+++ b/app/services/api/info_service.rb
@@ -29,7 +29,11 @@ module Api
       item  = find_by_identifier(documents, item_id)
       asset = find_by_identifier(documents, asset_id)
 
-      return not_found_result if item.nil? || asset.nil?
+      missing_ids = []
+      missing_ids << "item_id=#{item_id}" unless item
+      missing_ids << "asset_id=#{asset_id}" unless asset
+
+      return not_found_result(missing_ids) if missing_ids.any?
 
       success(format_metadata(item, asset))
     rescue RSolr::Error::Http => e
@@ -109,12 +113,13 @@ module Api
       )
     end
 
-    def not_found_result
-      failure(
-        "One or both Solr documents could not be found.",
+    def not_found_result(missing_ids)
+    failure(
+        "Solr document(s) not found for identifier(s): #{missing_ids.join(', ')}",
         "not_found",
         :not_found
-      )
+    )
     end
-  end
+
+end
 end

--- a/app/services/api/info_service.rb
+++ b/app/services/api/info_service.rb
@@ -1,0 +1,120 @@
+module Api
+  class InfoService
+    Result = Data.define(
+      :success?,
+      :data,
+      :error_message,
+      :error_code,
+      :status
+    )
+
+    METADATA_FIELDS = {
+      title: "title_display_ssm",
+      author: "primary_name_ssm",
+      dateCreated: "origin_info_date_created_ssm",
+      collection: "lib_collection_ssm",
+      extent: "physical_description_extent_ssm"
+    }.freeze
+
+    class DuplicateIdentifierError < StandardError; end
+
+    def initialize(item_id, asset_id)
+      @item_id = item_id
+      @asset_id = asset_id
+    end
+
+    def call
+      documents = search_documents
+
+      item  = find_by_identifier(documents, item_id)
+      asset = find_by_identifier(documents, asset_id)
+
+      return not_found_result if item.nil? || asset.nil?
+
+      success(format_metadata(item, asset))
+    rescue RSolr::Error::Http => e
+      failure(
+        "Unable to query Solr: #{e.message}",
+        "solr_error",
+        :service_unavailable
+      )
+    end
+
+    private
+
+    attr_reader :item_id, :asset_id
+
+    def repository
+      @repository ||= Blacklight::Solr::Repository.new(
+        CatalogController.blacklight_config
+      )
+    end
+
+    def search_documents
+      repository.search(
+        q: "*:*",
+        fq: [identifier_filter],
+        rows: 2
+      ).documents
+    end
+
+    def identifier_filter
+      %(identifier_ssim:("#{solr_escape(item_id)}" OR "#{solr_escape(asset_id)}"))
+    end
+
+    def find_by_identifier(documents, identifier)
+      matches = documents.filter do |doc|
+        Array(doc["identifier_ssim"]).include?(identifier)
+      end
+
+      raise DuplicateIdentifierError, identifier if matches.many?
+
+      matches.first
+    end
+
+    def format_metadata(item, asset)
+      METADATA_FIELDS.each_with_object(
+        identifier: item['id'],
+        imageSourceUrl: "https://triclops.library.columbia.edu/iiif/2/standard/#{asset['id']}/full/!1280,1280/0/default.jpg"
+      ) do |(key, solr_field), hash|
+        hash[key] = extract_first_value(item, solr_field)
+      end
+    end
+
+    def extract_first_value(item, key)
+      item.fetch(key, []).first.presence || ""
+    end
+
+    def solr_escape(id)
+      RSolr.solr_escape(id)
+    end
+
+    def success(data)
+      Result.new(
+        success?: true,
+        data: data,
+        error_message: nil,
+        error_code: nil,
+        status: :ok
+      )
+    end
+
+    def failure(message, code, status)
+      Result.new(
+        success?: false,
+        data: nil,
+        error_message: message,
+        error_code: code,
+        status: status
+      )
+    end
+
+    def not_found_result
+      failure(
+        "One or both Solr documents could not be found.",
+        "not_found",
+        :not_found
+      )
+    end
+  end
+end

--- a/app/services/api/info_service.rb
+++ b/app/services/api/info_service.rb
@@ -86,7 +86,7 @@ module Api
     end
 
     def extract_first_value(item, key)
-      item.fetch(key, []).first.presence || ""
+      item.fetch(key, []).first.presence || "null"
     end
 
     def solr_escape(id)

--- a/app/services/api/info_service.rb
+++ b/app/services/api/info_service.rb
@@ -10,7 +10,7 @@ module Api
 
     METADATA_FIELDS = {
       title: "title_display_ssm",
-      names: "primary_name_ssm",
+      names: "lib_name_ssm",
       dateCreated: "origin_info_date_created_ssm",
       collection: "lib_collection_ssm",
       extent: "physical_description_extent_ssm"
@@ -89,21 +89,23 @@ module Api
       }
 
       METADATA_FIELDS.each do |key, solr_field|
-        value =
-          if key == :names
-            extract_all_values(item, solr_field)
-          else
-            extract_first_value(item, solr_field)
-          end
+          value =
+            if key == :names
+              extract_multiple_values(item, solr_field, 10)
+            else
+              extract_first_value(item, solr_field)
+            end
 
-        hash[key] = value if value.present?
-      end
+          hash[key] = value if value.present?
+        end
 
-      hash
+        hash
     end
 
-    def extract_all_values(item, key)
-      Array(item[key]).compact_blank.presence
+    def extract_multiple_values(item, key, limit = nil)
+      values = Array(item[key]).compact_blank
+      values = values.take(limit) if limit
+      values.presence
     end
 
     def extract_first_value(item, key)

--- a/app/services/api/info_service.rb
+++ b/app/services/api/info_service.rb
@@ -79,7 +79,13 @@ module Api
     def format_metadata(item, asset)
       METADATA_FIELDS.each_with_object(
         identifier: item['id'],
-        imageSourceUrl: "https://triclops.library.columbia.edu/iiif/2/standard/#{asset['id']}/full/!1280,1280/0/default.jpg"
+        imageSourceUrl: Dcv::Utils::CdnUtils.asset_url(
+          id: asset['id'],
+          region: 'full',
+          width: 1280,
+          height: 1280,
+          format: 'jpg'
+        )
       ) do |(key, solr_field), hash|
         hash[key] = extract_first_value(item, solr_field)
       end

--- a/app/services/api/info_service.rb
+++ b/app/services/api/info_service.rb
@@ -10,7 +10,7 @@ module Api
 
     METADATA_FIELDS = {
       title: "title_display_ssm",
-      author: "primary_name_ssm",
+      names: "primary_name_ssm",
       dateCreated: "origin_info_date_created_ssm",
       collection: "lib_collection_ssm",
       extent: "physical_description_extent_ssm"
@@ -77,22 +77,37 @@ module Api
     end
 
     def format_metadata(item, asset)
-      METADATA_FIELDS.each_with_object(
-        identifier: item['id'],
+      hash = {
+        identifier: item["id"],
         imageSourceUrl: Dcv::Utils::CdnUtils.asset_url(
-          id: asset['id'],
-          region: 'full',
+          id: asset["id"],
+          region: "full",
           width: 1280,
           height: 1280,
-          format: 'jpg'
+          format: "jpg"
         )
-      ) do |(key, solr_field), hash|
-        hash[key] = extract_first_value(item, solr_field)
+      }
+
+      METADATA_FIELDS.each do |key, solr_field|
+        value =
+          if key == :names
+            extract_all_values(item, solr_field)
+          else
+            extract_first_value(item, solr_field)
+          end
+
+        hash[key] = value if value.present?
       end
+
+      hash
+    end
+
+    def extract_all_values(item, key)
+      Array(item[key]).compact_blank.presence
     end
 
     def extract_first_value(item, key)
-      item.fetch(key, []).first.presence || "null"
+      Array(item[key]).first.presence
     end
 
     def solr_escape(id)
@@ -120,12 +135,11 @@ module Api
     end
 
     def not_found_result(missing_ids)
-    failure(
+      failure(
         "Solr document(s) not found for identifier(s): #{missing_ids.join(', ')}",
         "not_found",
         :not_found
-    )
+      )
     end
-
-end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,12 @@ Rails.application.routes.draw do
     post '/upload', to: 'uploads#create'
   end
 
+  namespace :api do
+    namespace :v1 do
+      get 'external_display/info', to: 'external_display#info'
+    end
+  end
+
   get '/browse/:list_id' => 'browse', as: :browse, action: 'list'
   get '/explore' => 'welcome#home'
   get '/about' => 'pages#about', as: :about

--- a/spec/requests/api/v1/external_display_spec.rb
+++ b/spec/requests/api/v1/external_display_spec.rb
@@ -1,0 +1,183 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::ExternalDisplayController', type: :request do
+  describe 'GET /api/v1/external_display/info' do
+    let(:item_id) { '123' }
+    let(:asset_id) { 'abc' }
+
+    let(:response_data) do
+      {
+        requested_at: Time.current.iso8601,
+        document_one: {
+          id: item_id,
+          identifier: item_id,
+          title: 'Test Item'
+        },
+        document_two: {
+          id: asset_id,
+          identifier: asset_id,
+          title: 'Test Asset'
+        }
+      }
+    end
+
+    let(:error_message) { 'Record not found' }
+    let(:error_code) { nil }
+    let(:status) { nil }
+
+    let(:service_result) do
+      instance_double(
+        Api::InfoService::Result,
+        success?: success,
+        data: response_data,
+        error_message: error_message,
+        error_code: error_code,
+        status: status
+      )
+    end
+
+    let(:service) do
+      instance_double(Api::InfoService, call: service_result)
+    end
+
+    before do
+      allow(Api::InfoService)
+        .to receive(:new)
+        .and_return(service)
+    end
+
+    def json
+      JSON.parse(response.body)
+    end
+
+    context 'when the request is successful' do
+      let(:success) { true }
+
+      it 'returns a successful response with JSON data' do
+        get '/api/v1/external_display/info',
+            params: {
+              itemId: item_id,
+              assetId: asset_id
+            }
+
+        expect(response).to have_http_status(:ok)
+
+        expect(json).to eq(
+          'requested_at' => response_data[:requested_at],
+          'document_one' => {
+            'id' => item_id,
+            'identifier' => item_id,
+            'title' => 'Test Item'
+          },
+          'document_two' => {
+            'id' => asset_id,
+            'identifier' => asset_id,
+            'title' => 'Test Asset'
+          }
+        )
+
+        expect(Api::InfoService).to have_received(:new).with(
+          item_id,
+          asset_id
+        )
+      end
+    end
+
+    context 'when the service fails' do
+      let(:success) { false }
+      let(:error_code) { 'not_found' }
+      let(:status) { :not_found }
+
+      it 'returns a not found response' do
+        get '/api/v1/external_display/info',
+            params: {
+              itemId: item_id,
+              assetId: asset_id
+            }
+
+        expect(response).to have_http_status(:not_found)
+
+        expect(json).to eq(
+          'error' => {
+            'code' => 'not_found',
+            'message' => error_message
+          }
+        )
+      end
+    end
+
+    context 'when itemId is missing' do
+      let(:success) { true }
+
+      it 'returns bad request' do
+        get '/api/v1/external_display/info',
+            params: {
+              assetId: asset_id
+            }
+
+        expect(response).to have_http_status(:bad_request)
+
+        expect(json['error']['code']).to eq('missing_parameter')
+        expect(json['error']['message']).to include('itemId')
+      end
+    end
+
+    context 'when assetId is missing' do
+      let(:success) { true }
+
+      it 'returns bad request' do
+        get '/api/v1/external_display/info',
+            params: {
+              itemId: item_id
+            }
+
+        expect(response).to have_http_status(:bad_request)
+
+        expect(json['error']['code']).to eq('missing_parameter')
+        expect(json['error']['message']).to include('assetId')
+      end
+    end
+
+    context 'when itemId is blank' do
+      let(:success) { true }
+
+      it 'returns bad request' do
+        get '/api/v1/external_display/info',
+            params: {
+              itemId: '',
+              assetId: asset_id
+            }
+
+        expect(response).to have_http_status(:bad_request)
+
+        expect(json).to eq(
+          'error' => {
+            'code' => 'missing_parameter',
+            'message' => 'param is missing or the value is empty: itemId'
+          }
+        )
+      end
+    end
+
+    context 'when assetId is blank' do
+      let(:success) { true }
+
+      it 'returns bad request' do
+        get '/api/v1/external_display/info',
+            params: {
+              itemId: item_id,
+              assetId: ''
+            }
+
+        expect(response).to have_http_status(:bad_request)
+
+        expect(json).to eq(
+          'error' => {
+            'code' => 'missing_parameter',
+            'message' => 'param is missing or the value is empty: assetId'
+          }
+        )
+      end
+    end
+  end
+end

--- a/spec/services/api/info_service_spec.rb
+++ b/spec/services/api/info_service_spec.rb
@@ -116,13 +116,13 @@ RSpec.describe Api::InfoService do
         }
       end
 
-      it "returns empty strings for missing metadata" do
+      it "returns null for missing metadata" do
         expect(result.data).to include(
-          title: "",
-          author: "",
-          dateCreated: "",
-          collection: "",
-          extent: ""
+          title: "null",
+          author: "null",
+          dateCreated: "null",
+          collection: "null",
+          extent: "null"
         )
       end
     end

--- a/spec/services/api/info_service_spec.rb
+++ b/spec/services/api/info_service_spec.rb
@@ -1,0 +1,175 @@
+require "rails_helper"
+
+RSpec.describe Api::InfoService do
+  subject(:result) { described_class.new(item_id, asset_id).call }
+
+  let(:item_id) { "item-123" }
+  let(:asset_id) { "asset-456" }
+
+  let(:item_document) do
+    {
+      "id" => "item-solr-id",
+      "identifier_ssim" => [item_id],
+      "title_display_ssm" => ["My 1901 Collection"],
+      "primary_name_ssm" => ["Ann Author"],
+      "origin_info_date_created_ssm" => ["1901"],
+      "lib_collection_ssm" => ["Special Collections"],
+      "physical_description_extent_ssm" => ["12 pages"]
+    }
+  end
+
+  let(:asset_document) do
+    {
+      "id" => "asset-solr-id",
+      "identifier_ssim" => [asset_id]
+    }
+  end
+
+  before do
+    allow_any_instance_of(described_class)
+      .to receive(:search_documents)
+      .and_return([item_document, asset_document])
+  end
+
+  describe "#call" do
+    context "when both documents are found" do
+      it "returns a successful result" do
+        expect(result.success?).to be(true)
+        expect(result.status).to eq(:ok)
+      end
+
+      it "returns formatted metadata" do
+        expect(result.data).to eq(
+          identifier: "item-solr-id",
+          imageSourceUrl: "https://triclops.library.columbia.edu/iiif/2/standard/asset-solr-id/full/!1280,1280/0/default.jpg",
+          title: "My 1901 Collection",
+          author: "Ann Author",
+          dateCreated: "1901",
+          collection: "Special Collections",
+          extent: "12 pages"
+        )
+      end
+
+      it "does not include errors" do
+        expect(result.error_message).to be_nil
+        expect(result.error_code).to be_nil
+      end
+    end
+
+    context "when the item document is missing" do
+      before do
+        allow_any_instance_of(described_class)
+          .to receive(:search_documents)
+          .and_return([asset_document])
+      end
+
+      it "returns not found" do
+        expect(result.success?).to be(false)
+        expect(result.status).to eq(:not_found)
+        expect(result.error_code).to eq("not_found")
+      end
+    end
+
+    context "when the asset document is missing" do
+      before do
+        allow_any_instance_of(described_class)
+          .to receive(:search_documents)
+          .and_return([item_document])
+      end
+
+      it "returns not found" do
+        expect(result.success?).to be(false)
+        expect(result.status).to eq(:not_found)
+        expect(result.error_code).to eq("not_found")
+      end
+    end
+
+    context "when metadata fields are missing" do
+      let(:item_document) do
+        {
+          "id" => "item-solr-id",
+          "identifier_ssim" => [item_id]
+        }
+      end
+
+      it "returns empty strings for missing metadata" do
+        expect(result.data).to include(
+          title: "",
+          author: "",
+          dateCreated: "",
+          collection: "",
+          extent: ""
+        )
+      end
+    end
+
+    context "when Solr raises an HTTP error" do
+    let(:solr_error) do 
+        RSolr::Error::Http.new(
+          { uri: URI("http://localhost:8983/solr") }, 
+          { status: 503, body: "Solr unavailable" }
+        )
+      end
+
+      before do
+        allow_any_instance_of(described_class)
+          .to receive(:search_documents)
+          .and_raise(solr_error)
+      end
+
+      it "returns a failure result" do
+        expect(result.success?).to be(false)
+        expect(result.status).to eq(:service_unavailable)
+        expect(result.error_code).to eq("solr_error")
+        expect(result.error_message)
+          .to include("Unable to query Solr")
+      end
+    end
+
+    context "when duplicate item identifiers are returned" do
+      let(:duplicate_item) do
+        item_document.merge(
+          "id" => "duplicate-item-id"
+        )
+      end
+
+      before do
+        allow_any_instance_of(described_class)
+          .to receive(:search_documents)
+          .and_return([item_document, duplicate_item, asset_document])
+      end
+
+      it "raises DuplicateIdentifierError" do
+        expect do
+          result
+        end.to raise_error(
+          Api::InfoService::DuplicateIdentifierError,
+          item_id
+        )
+      end
+    end
+
+    context "when duplicate asset identifiers are returned" do
+      let(:duplicate_asset) do
+        asset_document.merge(
+          "id" => "duplicate-asset-id"
+        )
+      end
+
+      before do
+        allow_any_instance_of(described_class)
+          .to receive(:search_documents)
+          .and_return([item_document, asset_document, duplicate_asset])
+      end
+
+      it "raises DuplicateIdentifierError" do
+        expect do
+          result
+        end.to raise_error(
+          Api::InfoService::DuplicateIdentifierError,
+          asset_id
+        )
+      end
+    end
+  end
+end

--- a/spec/services/api/info_service_spec.rb
+++ b/spec/services/api/info_service_spec.rb
@@ -63,10 +63,13 @@ RSpec.describe Api::InfoService do
           .and_return([asset_document])
       end
 
-      it "returns not found" do
+      it "returns not found with the missing item identifier" do
         expect(result.success?).to be(false)
         expect(result.status).to eq(:not_found)
         expect(result.error_code).to eq("not_found")
+        expect(result.error_message).to eq(
+          "Solr document(s) not found for identifier(s): item_id=#{item_id}"
+        )
       end
     end
 
@@ -77,10 +80,31 @@ RSpec.describe Api::InfoService do
           .and_return([item_document])
       end
 
-      it "returns not found" do
+      it "returns not found with the missing asset identifier" do
         expect(result.success?).to be(false)
         expect(result.status).to eq(:not_found)
         expect(result.error_code).to eq("not_found")
+        expect(result.error_message).to eq(
+          "Solr document(s) not found for identifier(s): asset_id=#{asset_id}"
+        )
+      end
+    end
+
+    context "when both documents are missing" do
+      before do
+        allow_any_instance_of(described_class)
+          .to receive(:search_documents)
+          .and_return([])
+      end
+
+      it "returns all missing identifiers" do
+        expect(result.success?).to be(false)
+        expect(result.status).to eq(:not_found)
+        expect(result.error_code).to eq("not_found")
+        expect(result.error_message).to eq(
+          "Solr document(s) not found for identifier(s): " \
+          "item_id=#{item_id}, asset_id=#{asset_id}"
+        )
       end
     end
 

--- a/spec/services/api/info_service_spec.rb
+++ b/spec/services/api/info_service_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Api::InfoService do
       it "returns formatted metadata" do
         expect(result.data).to eq(
           identifier: "item-solr-id",
-          imageSourceUrl: "https://triclops.library.columbia.edu/iiif/2/standard/asset-solr-id/full/!1280,1280/0/default.jpg",
+          imageSourceUrl: "http://localhost/iiif/2/standard/asset-solr-id/full/!1280,1280/0/default.jpg",
           title: "My 1901 Collection",
           author: "Ann Author",
           dateCreated: "1901",

--- a/spec/services/api/info_service_spec.rb
+++ b/spec/services/api/info_service_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Api::InfoService do
       "id" => "item-solr-id",
       "identifier_ssim" => [item_id],
       "title_display_ssm" => ["My 1901 Collection"],
-      "primary_name_ssm" => ["Ann Author", "Bob Author"],
+      "lib_name_ssm" => ["Ann Author", "Bob Author"],
       "origin_info_date_created_ssm" => ["1901"],
       "lib_collection_ssm" => ["Special Collections"],
       "physical_description_extent_ssm" => ["12 pages"]
@@ -56,13 +56,13 @@ RSpec.describe Api::InfoService do
       end
     end
 
-    context "when multiple names are present" do
+    context "when multiple names are present (under the limit)" do
       let(:item_document) do
         {
           "id" => "item-solr-id",
           "identifier_ssim" => [item_id],
           "title_display_ssm" => ["My 1901 Collection"],
-          "primary_name_ssm" => [
+          "lib_name_ssm" => [
             "Ann Author",
             "Bob Author",
             "Real Author"
@@ -77,6 +77,26 @@ RSpec.describe Api::InfoService do
         expect(result.data[:names]).to eq(
           ["Ann Author", "Bob Author", "Real Author"]
         )
+      end
+    end
+
+    context "when more than 10 names are present" do
+      let(:twelve_names) { (1..12).map { |i| "Author #{i}" } }
+      let(:item_document) do
+        {
+          "id" => "item-solr-id",
+          "identifier_ssim" => [item_id],
+          "title_display_ssm" => ["My 1901 Collection"],
+          "lib_name_ssm" => twelve_names,
+          "origin_info_date_created_ssm" => ["1901"],
+          "lib_collection_ssm" => ["Special Collections"],
+          "physical_description_extent_ssm" => ["12 pages"]
+        }
+      end
+
+      it "limits the returned names to only the first 10" do
+        expect(result.data[:names].size).to eq(10)
+        expect(result.data[:names]).to eq((1..10).map { |i| "Author #{i}" })
       end
     end
 

--- a/spec/services/api/info_service_spec.rb
+++ b/spec/services/api/info_service_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Api::InfoService do
       "id" => "item-solr-id",
       "identifier_ssim" => [item_id],
       "title_display_ssm" => ["My 1901 Collection"],
-      "primary_name_ssm" => ["Ann Author"],
+      "primary_name_ssm" => ["Ann Author", "Bob Author"],
       "origin_info_date_created_ssm" => ["1901"],
       "lib_collection_ssm" => ["Special Collections"],
       "physical_description_extent_ssm" => ["12 pages"]
@@ -43,7 +43,7 @@ RSpec.describe Api::InfoService do
           identifier: "item-solr-id",
           imageSourceUrl: "http://localhost/iiif/2/standard/asset-solr-id/full/!1280,1280/0/default.jpg",
           title: "My 1901 Collection",
-          author: "Ann Author",
+          names: ["Ann Author", "Bob Author"],
           dateCreated: "1901",
           collection: "Special Collections",
           extent: "12 pages"
@@ -53,6 +53,30 @@ RSpec.describe Api::InfoService do
       it "does not include errors" do
         expect(result.error_message).to be_nil
         expect(result.error_code).to be_nil
+      end
+    end
+
+    context "when multiple names are present" do
+      let(:item_document) do
+        {
+          "id" => "item-solr-id",
+          "identifier_ssim" => [item_id],
+          "title_display_ssm" => ["My 1901 Collection"],
+          "primary_name_ssm" => [
+            "Ann Author",
+            "Bob Author",
+            "Real Author"
+          ],
+          "origin_info_date_created_ssm" => ["1901"],
+          "lib_collection_ssm" => ["Special Collections"],
+          "physical_description_extent_ssm" => ["12 pages"]
+        }
+      end
+
+      it "returns all names" do
+        expect(result.data[:names]).to eq(
+          ["Ann Author", "Bob Author", "Real Author"]
+        )
       end
     end
 
@@ -112,25 +136,29 @@ RSpec.describe Api::InfoService do
       let(:item_document) do
         {
           "id" => "item-solr-id",
+          "title_display_ssm" => ["My 1902 Collection"],
           "identifier_ssim" => [item_id]
         }
       end
 
-      it "returns null for missing metadata" do
-        expect(result.data).to include(
-          title: "null",
-          author: "null",
-          dateCreated: "null",
-          collection: "null",
-          extent: "null"
+      it "omits missing metadata keys from the payload" do
+        expect(result.data).to eq(
+          title: "My 1902 Collection",
+          identifier: "item-solr-id",
+          imageSourceUrl: "http://localhost/iiif/2/standard/asset-solr-id/full/!1280,1280/0/default.jpg"
         )
+
+        expect(result.data).not_to have_key(:names)
+        expect(result.data).not_to have_key(:dateCreated)
+        expect(result.data).not_to have_key(:collection)
+        expect(result.data).not_to have_key(:extent)
       end
     end
 
     context "when Solr raises an HTTP error" do
-    let(:solr_error) do 
+      let(:solr_error) do
         RSolr::Error::Http.new(
-          { uri: URI("http://localhost:8983/solr") }, 
+          { uri: URI("http://localhost:8983/solr") },
           { status: 503, body: "Solr unavailable" }
         )
       end


### PR DESCRIPTION
[WEBHELP-335](https://columbiauniversitylibraries.atlassian.net/browse/WEBHELP-335)

This PR introduces a minimal api endpoint to provide the AEM project with metadata for images.

The endpoint can be accessed at the following url. It takes an itemId and assetId param, as shown.

https://dlc.library.columbia.edu/api/v1/external_display/info?itemId=5d7af658-8053-4cea-873d-ec0907226d12&assetId=dfd12cba-7f3b-4423-a389-d2e07992c6a2

The endpoint uses UUIDs as the identifiers for items and assets. 

The response format is a simple JSON object with fields for identifier, title, author, dateCreated, collection, extent and imageSourceUrl.

To enable testing via the AEM project the endpoint is currently live on prod, but will be merged into the main branch after this PR is accepted.