### PR TITLE
[DLC-1291] Add owner role to DLC

### DIFF
--- a/app/controllers/admin/uploads_controller.rb
+++ b/app/controllers/admin/uploads_controller.rb
@@ -5,7 +5,10 @@ module Admin
   class UploadsController < ApplicationController
     layout 'admin'
     before_action :authenticate_user!
-    before_action :authorize_import
+    before_action :authorize_view, only: [:new]
+    before_action :load_subsite, only: [:create]
+    before_action :authorize_import, only: [:create]
+    rescue_from Dcv::Exceptions::SubsiteCreateUnauthorized, with: :handle_unauthorized_create
 
     # GET /admin/import
     def new; end
@@ -28,8 +31,25 @@ module Admin
 
     private
 
+    def handle_unauthorized_create
+      flash[:error] = "You are not authorized to create this subsite in this environment!."
+      render :new, status: :unprocessable_entity
+    end
+
+    def authorize_view
+      authorize_action_and_scope Ability::VIEW_IMPORT_FORM, Site
+    end
+
+    def load_subsite
+      @subsite ||= Site.find_by(slug: params[:slug])
+    end
+
     def authorize_import
-      authorize_action_and_scope Ability::IMPORT_SUBSITE, Site
+      if @subsite.nil?
+        raise Dcv::Exceptions::SubsiteCreateUnauthorized unless can? Ability::IMPORT_NEW_SUBSITE, Site
+      else
+        raise Dcv::Exceptions::SubsiteCreateUnauthorized unless can? Ability::IMPORT_SUBSITE, @subsite
+      end
     end
   end
 end

--- a/app/controllers/sites/permissions_controller.rb
+++ b/app/controllers/sites/permissions_controller.rb
@@ -19,6 +19,7 @@ module Sites
 				update_attributes = permissions_params
 				update_attributes[:permissions]&.tap {|atts| @subsite.permissions.assign_attributes(atts) }
 				update_attributes[:editor_uids]&.tap {|atts| @subsite.editor_uids = atts }
+        update_attributes[:owner_uid]&.tap { |atts| @subsite.owner_uid = atts }
 				@subsite.save! if @subsite.changed?
 				flash[:notice] = "Saved!"
 			rescue ActiveRecord::RecordInvalid => ex
@@ -41,9 +42,10 @@ module Sites
 
 		def permissions_params
 			params['site']&.tap do |atts|
-				if can?(:admin, @subsite)
+				if can?(Ability::CHANGE_SUBSITE_OWNER_AND_EDITORS, @subsite)
 					atts['editor_uids']&.strip!
 					atts['editor_uids'] = atts['editor_uids'].split(/[\s,]+/).sort
+          atts['owner_uid']&.strip!
 				else
 					atts['editor_uids'] = @subsite.editor_uids
 				end
@@ -51,7 +53,7 @@ module Sites
 			params.dig('site', 'permissions')&.tap do |atts|
 				atts['remote_ids'] = atts['remote_ids'].split(/[\s,]+/).sort if atts&.fetch('remote_ids', nil)
 			end
-			params.require(:site).permit(editor_uids: [], permissions: {remote_ids: [], remote_roles: [], locations: []})
+			params.require(:site).permit(:owner_uid, editor_uids: [], permissions: {remote_ids: [], remote_roles: [], locations: []})
 		end
 	end
 end

--- a/app/controllers/sites/permissions_controller.rb
+++ b/app/controllers/sites/permissions_controller.rb
@@ -25,7 +25,6 @@ module Sites
 			rescue ActiveRecord::RecordInvalid => ex
 				flash[:alert] = ex.message
 			end
-			@subsite.save! if @subsite.changed?
 			if restricted?
 				redirect_to edit_restricted_site_permissions_path(site_slug: @subsite.slug.sub('restricted/', ''))
 			else

--- a/app/helpers/dcv/dcv_url_helper.rb
+++ b/app/helpers/dcv/dcv_url_helper.rb
@@ -91,7 +91,7 @@ module Dcv::DcvUrlHelper
   end
 
   def site_edit_link(sep: ' | ', **link_opts)
-    return unless (@subsite && can?(:update, @subsite))
+    return unless (@subsite && can?(Ability::MANAGE_SUBSITE, @subsite))
     return if controller.action_name == 'edit'
     if @page&.slug && (@page.slug.to_s != 'home')
       edit_href = edit_site_page_path(site_slug: @subsite.slug, slug: @page.slug)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -27,7 +27,7 @@ class Ability
       end
     end
     
-    #  can? current_user, :access_subsite, @subsite
+    # can? current_user, :access_subsite, @subsite
     can ACCESS_SUBSITE, Site do |site|
       if site.restricted
         result = false
@@ -36,7 +36,8 @@ class Ability
         result ||= true if (site.to_subsite_config.fetch(:locations, []).flatten & location_uris).first
         result
       else
-        true end
+        true 
+      end
     end
 
     can ACCESS_ASSET, SolrDocument do |doc|
@@ -85,6 +86,33 @@ class Ability
 
     can :admin, Site
   end
+
+
+  #   # A more robust solution would be to add a 'role' field to the user model, so
+  #   # we can do an O(1) operation instead of looking at each site when this method runs.
+  #   # The react frontend auth does something like that.
+  #   # Because we use sqlite3, we cannot do a query that gets the answer reliably (because
+  #   # the lookup for an id in the editor array matches substrings, not exacts)
+  #   is_editor_or_owner = Site.any? do |site|
+  #     site[:editor_uids].include?(user.uid) || site[:owner_uid] == user.uid
+  #   end
+
+  #   return unless is_editor_or_owner || user.is_admin
+
+  #   can LIST_SUBSITES, Site
+
+  #   can MANAGE_SUBSITE, Site do |site|
+  #     user.is_admin || user.uid == site.owner_uid || site.editor_uids.include?(user.uid)
+  #   end
+
+  #   can IMPORT_SUBSITE, Site do |site|
+  #     user.is_admin || user.uid == site.owner_uid || !Rails.env.dlc_prod?
+  #   end
+
+  #   return unless user.is_admin
+
+  #   can :admin, Site
+  # end
 
   # was this document published to a site where the current user has remote "onsite" permissions
   def remote_onsite_access_to_user?(doc, user = nil, affils = [])

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -26,11 +26,7 @@ class Ability
         true
       end
     end
-    # can? :list_subsites, Site
-    can LIST_SUBSITES, Site do
-      return true if user&.is_admin?
-      Site.all.any? { |site| site[:editor_uids].include? user[:uid] }
-    end
+    
     #  can? current_user, :access_subsite, @subsite
     can ACCESS_SUBSITE, Site do |site|
       if site.restricted
@@ -40,9 +36,9 @@ class Ability
         result ||= true if (site.to_subsite_config.fetch(:locations, []).flatten & location_uris).first
         result
       else
-        true
-      end
+        true end
     end
+
     can ACCESS_ASSET, SolrDocument do |doc|
       if doc.fetch('access_control_levels_ssim', []).include?(ACCESS_LEVEL_CLOSED)
         false
@@ -70,25 +66,24 @@ class Ability
         result
       end
     end
-    can MANAGE_SUBSITE, Site do |site|
-      user&.is_admin || site.editor_uids.include?(user&.uid)
-    end
-    can :update, Site do |site|
-      user&.is_admin || site.editor_uids.include?(user&.uid)
-    end
-    can :admin, Site do |site|
-      user&.is_admin
-    end
-    # Authorization rules:
-    #   - in dlc_prod: only dlc admin may import a site
-    #   - else: only dlc admin or an editor of *some* site may import a site
-    # N.B.: in non-prod environments, an editor may import a site or new site
-    #       without restriction. Some ideas to make this more secure:
-    #         - users must enter the slug for the site they are updating, and if
-    #           it doesn't match the metadata of the import, we reject the operation
-    #         - users may not upload a new site unless they are admin
+
+    return unless user.present?
+
     is_editor = Site.any? { |site| site[:editor_uids].include? user&.uid }
-    can IMPORT_SUBSITE, Site if user&.is_admin || (!Rails.env.dlc_prod? && is_editor)
+
+    return unless is_editor || user.is_admin
+    
+    can LIST_SUBSITES, Site
+
+    can MANAGE_SUBSITE, Site do |site|
+      user.is_admin || site.editor_uids.include?(user.uid)
+    end
+
+    can IMPORT_SUBSITE, Site if user.is_admin || !Rails.env.dlc_prod?
+
+    return unless user.is_admin
+
+    can :admin, Site
   end
 
   # was this document published to a site where the current user has remote "onsite" permissions

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -8,7 +8,7 @@ class Ability
   IMPORT_SUBSITE = :import_subsite
   IMPORT_NEW_SUBSITE = :import_new_subsite
   VIEW_IMPORT_FORM = :view_import_form
-  EDIT_SUBSITES = :edit
+  CHANGE_SUBSITE_OWNER_AND_EDITORS = :change_subsite_owner
   LIST_SUBSITES = :list_subsites
   MANAGE_SUBSITE = :manage_subsite
   UNSPECIFIED_ACCESS_DECISION = true
@@ -95,11 +95,20 @@ class Ability
       user.is_admin || user.uid == site.owner_uid || !Rails.env.dlc_prod?
     end
 
+    return unless is_owner || user.is_admin
+
+    can CHANGE_SUBSITE_OWNER_AND_EDITORS, Site do |site|
+      user.is_admin || user.uid == site.owner_uid
+    end
+
+    # :admin is still used in tombstone grid display field: app/views/sites/search_configuration/_display_options_form.html.erb
+    # TODO: should this be admin only, or admin and owner?
+    can :admin, Site
+
     return unless user.is_admin
 
     can IMPORT_NEW_SUBSITE, Site
 
-    can :admin, Site
   end
 
   # was this document published to a site where the current user has remote "onsite" permissions

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -6,6 +6,8 @@ class Ability
   ACCESS_ASSET = :access_asset
   ACCESS_SUBSITE = :access_subsite
   IMPORT_SUBSITE = :import_subsite
+  IMPORT_NEW_SUBSITE = :import_new_subsite
+  VIEW_IMPORT_FORM = :view_import_form
   EDIT_SUBSITES = :edit
   LIST_SUBSITES = :list_subsites
   MANAGE_SUBSITE = :manage_subsite
@@ -70,49 +72,35 @@ class Ability
 
     return unless user.present?
 
-    is_editor = Site.any? { |site| site[:editor_uids].include? user&.uid }
+    # A more robust solution would be to add a 'role' field to the user model, so
+    # we can do an O(1) operation instead of potentially looking at each site when these are calculated.
+    # The react frontend auth does something like that.
+    # Because we use sqlite3, we cannot do a query that gets the answer reliably (because
+    # the lookup for an id in the editor array matches substrings, not exacts)
+    is_editor = Site.any? { |site| site[:editor_uids].include?(user.uid) }
+    is_owner = Site.any? { |site| site[:owner_uid] == user.uid }
 
-    return unless is_editor || user.is_admin
-    
+    return unless is_editor || is_owner || user.is_admin
+
     can LIST_SUBSITES, Site
 
     can MANAGE_SUBSITE, Site do |site|
-      user.is_admin || site.editor_uids.include?(user.uid)
+      user.is_admin || user.uid == site.owner_uid || site.editor_uids.include?(user.uid)
     end
 
-    can IMPORT_SUBSITE, Site if user.is_admin || !Rails.env.dlc_prod?
+    # In prod, only admins and owners can view the import form
+    can VIEW_IMPORT_FORM, Site if !Rails.env.dlc_prod? || is_owner || user.is_admin
+
+    can IMPORT_SUBSITE, Site do |site|
+      user.is_admin || user.uid == site.owner_uid || !Rails.env.dlc_prod?
+    end
 
     return unless user.is_admin
 
+    can IMPORT_NEW_SUBSITE, Site
+
     can :admin, Site
   end
-
-
-  #   # A more robust solution would be to add a 'role' field to the user model, so
-  #   # we can do an O(1) operation instead of looking at each site when this method runs.
-  #   # The react frontend auth does something like that.
-  #   # Because we use sqlite3, we cannot do a query that gets the answer reliably (because
-  #   # the lookup for an id in the editor array matches substrings, not exacts)
-  #   is_editor_or_owner = Site.any? do |site|
-  #     site[:editor_uids].include?(user.uid) || site[:owner_uid] == user.uid
-  #   end
-
-  #   return unless is_editor_or_owner || user.is_admin
-
-  #   can LIST_SUBSITES, Site
-
-  #   can MANAGE_SUBSITE, Site do |site|
-  #     user.is_admin || user.uid == site.owner_uid || site.editor_uids.include?(user.uid)
-  #   end
-
-  #   can IMPORT_SUBSITE, Site do |site|
-  #     user.is_admin || user.uid == site.owner_uid || !Rails.env.dlc_prod?
-  #   end
-
-  #   return unless user.is_admin
-
-  #   can :admin, Site
-  # end
 
   # was this document published to a site where the current user has remote "onsite" permissions
   def remote_onsite_access_to_user?(doc, user = nil, affils = [])

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -12,7 +12,7 @@ class Site < ApplicationRecord
 	attribute :permissions, :site_permissions, default: -> {Site::Permissions.new}
 	serialize :editor_uids, Array
 	serialize :image_uris, Array
-	belongs_to :owner, class_name: 'User', foreign_key: 'owner_uid', primary_key: 'uid', optional: true
+	belongs_to :owner, class_name: 'User', foreign_key: 'owner_uid', primary_key: 'uid'
   validates :owner_uid, presence: true # this value must be present, but we allow optional: true on the association to handle cases where the owner's User model does not yet exist
 
 	validates :search_type, inclusion: { in: VALID_SEARCH_TYPES }

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -13,7 +13,7 @@ class Site < ApplicationRecord
 	serialize :editor_uids, Array
 	serialize :image_uris, Array
 	belongs_to :owner, class_name: 'User', foreign_key: 'owner_uid', primary_key: 'uid'
-  validates :owner_uid, presence: true # this value must be present, but we allow optional: true on the association to handle cases where the owner's User model does not yet exist
+  validates :owner_uid, presence: true
 
 	validates :search_type, inclusion: { in: VALID_SEARCH_TYPES }
 	validates :layout, inclusion: { in: VALID_LAYOUTS }

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -12,6 +12,8 @@ class Site < ApplicationRecord
 	attribute :permissions, :site_permissions, default: -> {Site::Permissions.new}
 	serialize :editor_uids, Array
 	serialize :image_uris, Array
+	belongs_to :owner, class_name: 'User', foreign_key: 'owner_uid', primary_key: 'uid', optional: true
+  validates :owner_uid, presence: true # this value must be present, but we allow optional: true on the association to handle cases where the owner's User model does not yet exist
 
 	validates :search_type, inclusion: { in: VALID_SEARCH_TYPES }
 	validates :layout, inclusion: { in: VALID_LAYOUTS }

--- a/app/services/subsite_export_service.rb
+++ b/app/services/subsite_export_service.rb
@@ -33,7 +33,7 @@ require 'zip'
 #
 # This service is used by the sites_controller in the download action
 
-DB_FIELDS = ['id', 'created_at', 'site_id', 'site_page_id', 'updated_at']
+DB_FIELDS = ['id', 'created_at', 'site_id', 'owner_uid', 'site_page_id', 'updated_at']
 
 class SubsiteExportService
   include Dcv::Sites::Constants

--- a/app/services/subsite_import_service.rb
+++ b/app/services/subsite_import_service.rb
@@ -176,6 +176,7 @@ class SubsiteImportService
     site.permissions = Site::Permissions.new(attrs['permissions'])
     site.image_uris = attrs['image_uris']
     site.publisher_uri = attrs['publisher_uri']
+    site.owner_uid = attrs['owner_uid'] || DEFAULT_OWNER
 
     create_site_search_configuration(zip)
 

--- a/app/services/subsite_import_service.rb
+++ b/app/services/subsite_import_service.rb
@@ -177,7 +177,8 @@ class SubsiteImportService
     site.permissions = Site::Permissions.new(attrs['permissions'])
     site.image_uris = attrs['image_uris']
     site.publisher_uri = attrs['publisher_uri']
-    site.owner_uid = attrs['owner_uid'] || DEFAULT_OWNER
+    owner_uid = attrs['owner_uid'] || DEFAULT_OWNER
+    site.owner = User.find_or_create_by(uid: owner_uid)
 
     create_site_search_configuration(zip)
 

--- a/app/services/subsite_import_service.rb
+++ b/app/services/subsite_import_service.rb
@@ -59,6 +59,7 @@ class SubsiteImportService
         @attrs = YAML.load zis.read
       end
       new_subsite = Site.find_by(slug: @attrs['slug']).nil?
+      # Equivalent of `can? Ability::IMPORT_NEW_SUBSITE, Site`
       if new_subsite && !@is_admin
         raise Dcv::Exceptions::SubsiteUploadError.new('You are not authorized to import a new site to the DLC. If this is an error, please contact a DLC administrator to receive admin privileges.')
       end

--- a/app/views/admin/uploads/new.html.erb
+++ b/app/views/admin/uploads/new.html.erb
@@ -1,18 +1,24 @@
 
-<div>
+<div class="m-3">
   <h2>Import a subsite to DLC - <span class="text-dark fst-italic"><%= Rails.env %></span> environment</h2>
   <p>Administrators and editors have the ability to create zipped exports of DLC subsites. To do so, visit the editor interface of the site you would like to export and click the "export subsite as zip file" button at the bottom of the Site Properties page.</p>
   <p>When migrating subsites between environments (for example, from the DLC staging environment to production), you can upload zipped subsite contents here to initiate a site import.</p>
   <p><strong class="text-danger">This will overwrite all the subsite data currently saved and displayed in this environment (<em><%= Rails.env %></em>). This operation cannot be undone.</strong></p>
-  <div id="import-subsite-form" class="p-3 border border-info rounded-4">
-
+  <div id="import-subsite-form" class="m-4 p-3 border border-info rounded-4">
     <%= render :partial=>'shared/flash_msg', layout: 'shared/flash_messages' %>
 
     <%= form_with url: "/admin/upload", multipart: true, class: 'd' do |form| %>
-      <div>
+      <div class="p-3">
         <%= form.file_field :upload, required: true %>
       </div>
-      <div>
+      <div class="p-3">
+        <div class="text-secondary">
+        </div>
+        <%= form.label :subsite_slug %>
+        <%= form.collection_select :slug, Site.all, :slug, :slug, { include_blank: true }%>
+        <p class="text-secondary">If you are uploading a new subsite to the current environment, you should leave this field blank.<br />However, note that <span class="text-decoration-underline">only DLC Administrators</span> may perform a new subsite upload!</p>
+      </div>
+      <div class="p-3">
         <%= submit_tag "Upload Subsite Zip File", {class: ['btn', 'btn-primary btn-lg px-4 mt-3'] } %>
       </div>
     <% end %>

--- a/app/views/sites/permissions/_form.html.erb
+++ b/app/views/sites/permissions/_form.html.erb
@@ -8,12 +8,21 @@
 -%>
 <%= form_for @subsite, url: config_view, builder: ::ValueIndexableFormBuilder do |site_form| %>
 	<div class="card border-secondary">
-		<div class="card-header swatch-secondary"><h2 class="card-title">Site Editor IDs</h2></div>
+		<div class="card-header swatch-secondary"><h2 class="card-title">Site Owner and Editor IDs</h2></div>
 		<div class="card-body site_editors">
+			<div class="form-group mb-4">
+				<p>Site Owner and DLC admins: Enter the UNI of the CUL employee who is the owner of this site.</p>
+        <div class="row">
+          <label for="site_owner_uid" class="col-2">Site Owner UNI:</label>
+          <%= site_form.text_field(:owner_uid, {value: @subsite.owner_uid, class: ['form-control', 'col-2'], disabled: !can?(Ability::CHANGE_SUBSITE_OWNER_AND_EDITORS, @subsite)}) %>
+        </div>
+			</div>
 			<div class="form-group">
-				<label for="site_editor_uids">Site Editor UNIs</label>
-				<p>DLC admins: Enter the comma-separated UNIs of CUL employees authorized to edit this site.</p>
-				<%= site_form.text_area(:editor_uids, {value: @subsite.editor_uids.sort.join(",\n"), class: ['form-control'], disabled: !can?(:admin, @subsite)}) %>
+				<p>Site Owner and DLC admins: Enter the comma-separated UNIs of CUL employees authorized to edit this site.</p>
+        <div class="row">
+          <label for="site_editor_uids" class="col-2">Site Editor UNIs:</label>
+          <%= site_form.text_area(:editor_uids, {value: @subsite.editor_uids.sort.join(", "), class: ['form-control', 'col-9'], disabled: !can?(Ability::CHANGE_SUBSITE_OWNER_AND_EDITORS, @subsite)}) %>
+        </div>
 			</div>
 		</div>
 	</div>

--- a/config/templates/dcv.template.yml.erb
+++ b/config/templates/dcv.template.yml.erb
@@ -6,6 +6,7 @@ test:
   num_load_balanced_cdn_urls: 0
   cdn_urls:
   - http://localhost
+  default_owner: ta123
 development:
   require_authentication: false
   iiif:
@@ -14,3 +15,4 @@ development:
   num_load_balanced_cdn_urls: 0
   cdn_urls:
   - http://localhost
+  default_owner: ta123

--- a/db/migrate/20240925215831_add_repository_site_records.rb
+++ b/db/migrate/20240925215831_add_repository_site_records.rb
@@ -1,4 +1,13 @@
 class AddRepositorySiteRecords < ActiveRecord::Migration[6.1]
+  # Stub class isolated from the live Site model and its validations/callbacks.
+  # This prevents future changes to Site from breaking this migration when
+  # running from scratch.
+  class Site < ActiveRecord::Base
+    self.table_name = 'sites'
+    LAYOUT_REPOSITORIES = 'repositories'
+    SEARCH_REPOSITORIES = 'repositories'
+  end
+
   def change
     reversible do |direction|
       repository_ids = %w(NNC-A NNC-EA NNC-RB NyNyCAP NyNyCBL NyNyCMA)

--- a/db/migrate/20260616143646_add_owner_to_sites.rb
+++ b/db/migrate/20260616143646_add_owner_to_sites.rb
@@ -1,6 +1,7 @@
 class AddOwnerToSites < ActiveRecord::Migration[6.1]
   def change
     add_column(:sites, :owner_uid, :string)
-    change_column_null(:sites, :owner_uid, false, 'bal35')
+    default_owner = Rails.application.config_for(:dcv).default_owner
+    change_column_null(:sites, :owner_uid, false, default_owner)
   end
 end

--- a/db/migrate/20260616143646_add_owner_to_sites.rb
+++ b/db/migrate/20260616143646_add_owner_to_sites.rb
@@ -1,0 +1,6 @@
+class AddOwnerToSites < ActiveRecord::Migration[6.1]
+  def change
+    add_column(:sites, :owner_uid, :string)
+    change_column_null(:sites, :owner_uid, false, 'bal35')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_03_13_140719) do
+ActiveRecord::Schema.define(version: 2026_06_16_143646) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -104,6 +104,7 @@ ActiveRecord::Schema.define(version: 2026_03_13_140719) do
     t.boolean "show_facets", default: false
     t.text "editor_uids"
     t.text "search_configuration"
+    t.string "owner_uid", null: false
     t.index ["slug"], name: "index_sites_on_slug", unique: true
   end
 

--- a/lib/dcv/exceptions.rb
+++ b/lib/dcv/exceptions.rb
@@ -12,5 +12,6 @@ module Dcv
         super("There was an error processing the uploaded subsite: #{msg}")
       end
     end
+    class SubsiteCreateUnauthorized < StandardError; end
   end
 end

--- a/lib/dcv/sites.rb
+++ b/lib/dcv/sites.rb
@@ -23,7 +23,7 @@ module Dcv::Sites
 		DEFAULT_PALETTE = 'default' # use sitewide default at designers' discretion
 		CUSTOM_LAYOUT = 'custom'
 		VALID_LAYOUTS = [CUSTOM_LAYOUT, DEFAULT_LAYOUT].concat(PORTABLE_LAYOUTS).freeze
-    DEFAULT_OWNER = 'bal35'
+    DEFAULT_OWNER = Rails.application.config_for(:dcv).default_owner
 
 		def self.default_layout
 			DCV_CONFIG.fetch(:default_layout, 'portrait')

--- a/lib/dcv/sites.rb
+++ b/lib/dcv/sites.rb
@@ -23,6 +23,7 @@ module Dcv::Sites
 		DEFAULT_PALETTE = 'default' # use sitewide default at designers' discretion
 		CUSTOM_LAYOUT = 'custom'
 		VALID_LAYOUTS = [CUSTOM_LAYOUT, DEFAULT_LAYOUT].concat(PORTABLE_LAYOUTS).freeze
+    DEFAULT_OWNER = 'bal35'
 
 		def self.default_layout
 			DCV_CONFIG.fetch(:default_layout, 'portrait')

--- a/lib/dcv/sites/export/directory.rb
+++ b/lib/dcv/sites/export/directory.rb
@@ -2,7 +2,7 @@ require 'yaml'
 require 'json'
 
 module Dcv::Sites::Export
-	DB_FIELDS = ['id', 'created_at', 'owner_uid', 'site_id', 'site_page_id', 'updated_at']
+	DB_FIELDS = ['id', 'created_at', 'site_id', 'site_page_id', 'updated_at']
 	class Directory
 		include Dcv::Sites::Constants
 		def initialize(site, directory, db_fields = false)

--- a/lib/dcv/sites/export/directory.rb
+++ b/lib/dcv/sites/export/directory.rb
@@ -2,7 +2,7 @@ require 'yaml'
 require 'json'
 
 module Dcv::Sites::Export
-	DB_FIELDS = ['id', 'created_at', 'site_id', 'site_page_id', 'updated_at']
+	DB_FIELDS = ['id', 'created_at', 'owner_uid', 'site_id', 'site_page_id', 'updated_at']
 	class Directory
 		include Dcv::Sites::Constants
 		def initialize(site, directory, db_fields = false)

--- a/lib/dcv/sites/import/directory.rb
+++ b/lib/dcv/sites/import/directory.rb
@@ -55,6 +55,7 @@ module Dcv::Sites::Import
 				page.site_text_blocks.delete_all
 				page.delete
 			end
+      site.owner_uid = atts['owner_uid'] || DEFAULT_OWNER
 			site.save!
 			nav_links = Array(atts.delete('nav_links'))
 			nav_links.each do |link_atts|

--- a/lib/dcv/sites/import/directory.rb
+++ b/lib/dcv/sites/import/directory.rb
@@ -55,7 +55,8 @@ module Dcv::Sites::Import
 				page.site_text_blocks.delete_all
 				page.delete
 			end
-      site.owner_uid = atts['owner_uid'] || DEFAULT_OWNER
+      owner_uid = atts['owner_uid'] || DEFAULT_OWNER
+      site.owner = User.find_or_create_by(uid: owner_uid)
 			site.save!
 			nav_links = Array(atts.delete('nav_links'))
 			nav_links.each do |link_atts|

--- a/lib/dcv/sites/import/solr.rb
+++ b/lib/dcv/sites/import/solr.rb
@@ -48,7 +48,7 @@ module Dcv::Sites::Import
 					end
 				end
 			end
-      site.owner_uid = DEFAULT_OWNER
+      site.owner = User.find_or_create_by(uid: DEFAULT_OWNER)
 
 			unless site.save
 				Rails.logger.error("failed to import #{slug}:\n\t#{site.errors.inspect}")

--- a/lib/dcv/sites/import/solr.rb
+++ b/lib/dcv/sites/import/solr.rb
@@ -48,7 +48,7 @@ module Dcv::Sites::Import
 					end
 				end
 			end
-      site.owner_uid = 'ta123'
+      site.owner_uid = DEFAULT_OWNER
 
 			unless site.save
 				Rails.logger.error("failed to import #{slug}:\n\t#{site.errors.inspect}")

--- a/lib/dcv/sites/import/solr.rb
+++ b/lib/dcv/sites/import/solr.rb
@@ -48,6 +48,7 @@ module Dcv::Sites::Import
 					end
 				end
 			end
+      site.owner_uid = 'ta123'
 
 			unless site.save
 				Rails.logger.error("failed to import #{slug}:\n\t#{site.errors.inspect}")

--- a/lib/tasks/dcv/sites.rake
+++ b/lib/tasks/dcv/sites.rake
@@ -27,6 +27,7 @@ namespace :dcv do
     task export: 'export:site'
 
     task seed_from_solr: :environment do
+      Site.reset_column_information
       SolrDocument.each_site_document do |document|
         site_import = Dcv::Sites::Import::Solr.new(document)
         next unless site_import.exists?

--- a/spec/controllers/sites/permissions_controller_spec.rb
+++ b/spec/controllers/sites/permissions_controller_spec.rb
@@ -24,7 +24,7 @@ describe Sites::PermissionsController, type: :unit do
 		let(:is_admin) { false }
 		before do
 			controller.instance_variable_set(:@subsite, site)
-			allow(controller).to receive(:can?).with(:admin, site).and_return(is_admin)
+			allow(controller).to receive(:can?).with(Ability::CHANGE_SUBSITE_OWNER_AND_EDITORS, site).and_return(is_admin)
 		end
 		context 'with editor_uids text' do
 			let(:uids) { ['abc', 'bcd', 'cde'] }
@@ -70,7 +70,7 @@ describe Sites::PermissionsController, type: :unit do
 		let(:edit_site_permissions_path) { "/#{site.slug}/permissions/edit" }
 		before do
 			allow(controller).to receive(:authorize_site_update).and_return(true)
-			allow(controller).to receive(:can?).with(:admin, site).and_return(true)
+			allow(controller).to receive(:can?).with(Ability::CHANGE_SUBSITE_OWNER_AND_EDITORS, site).and_return(true)
 			allow(controller).to receive(:edit_site_permissions_path).with(site_slug: site.slug).and_return(edit_site_permissions_path)
 			expect(controller).to receive(:redirect_to).with(edit_site_permissions_path)
 		end

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -12,6 +12,7 @@ FactoryBot.define do
     image_uris { ['info:fedora/test-image:1'] }
     repository_id { 'NNC'}
     scope_filters { [build(:scope_filter, filter_type: 'collection', value: 'DLC Site Collection')] }
+    owner_uid { 'tester '}
 
     factory :site_with_links do
       after(:create) do |site|

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
     image_uris { ['info:fedora/test-image:1'] }
     repository_id { 'NNC'}
     scope_filters { [build(:scope_filter, filter_type: 'collection', value: 'DLC Site Collection')] }
-    owner_uid { 'tester '}
+    association :owner, factory: :user
 
     factory :site_with_links do
       after(:create) do |site|

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :user do
-    uid { 'tester' }
-    email { 'tester@example.org' }
+    sequence(:uid) { |n| "tester#{n}" }
+    sequence(:email) { |n| "person#{n}@example.com" }
     is_admin   { false }
   end
 end

--- a/spec/features/sites/pages_controller_spec.rb
+++ b/spec/features/sites/pages_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 describe ::Sites::PagesController, type: :feature do
+  let!(:owner) { FactoryBot.create(:user, uid: 'owner_uid') }
 	let(:source) { fixture("sites/import/directory").path }
 	let(:import) { Dcv::Sites::Import::Directory.new(source) }
 	let(:site_slug) { import.atts['slug'] }

--- a/spec/features/sites/permissions_controller_spec.rb
+++ b/spec/features/sites/permissions_controller_spec.rb
@@ -17,14 +17,16 @@ describe ::Sites::PermissionsController, type: :feature do
 			visit(edit_link_href)
 		end
 		it 'updates atts' do
-			fill_in('Remote Access UNIs', with: "remoteUser, remoteContributor")
-			fill_in('Site Editor UNIs', with: "adminUser, adminPartner")
+      fill_in('Site Owner UNI', with: 'adminUser')
+			fill_in('Remote Access UNIs', with: 'remoteUser, remoteContributor')
+			fill_in('Site Editor UNIs', with: 'adminUser, adminPartner')
 			click_button "Update Permissions"
 			# do a find to make sure page loaded
 			find('#site_permissions_remote_ids')
 			visit(edit_link_href)
-			expect(find_field('Remote Access UNIs').value).to eq("remoteContributor,\nremoteUser")			
-			expect(find_field('Site Editor UNIs').value).to eq("adminPartner,\nadminUser")			
+      expect(find_field('Site Owner UNI').value).to eq('adminUser')
+			expect(find_field('Remote Access UNIs').value).to eq("remoteContributor,\nremoteUser")
+			expect(find_field('Site Editor UNIs').value).to eq("adminPartner, adminUser")			
 		end
 	end
 	describe '#edit' do

--- a/spec/features/sites/permissions_controller_spec.rb
+++ b/spec/features/sites/permissions_controller_spec.rb
@@ -10,7 +10,7 @@ describe ::Sites::PermissionsController, type: :feature do
 	let(:edit_link_href) { "/#{site_slug}/permissions/edit" }
 	describe '#update' do
 		before { import.run }
-		let(:authorized_user) { FactoryBot.create(:user, is_admin: true) }
+		let(:authorized_user) { FactoryBot.create(:user, uid: 'adminUser', is_admin: true) }
 		before do
 			Warden.test_mode!
 			login_as authorized_user, scope: :user
@@ -28,6 +28,15 @@ describe ::Sites::PermissionsController, type: :feature do
 			expect(find_field('Remote Access UNIs').value).to eq("remoteContributor,\nremoteUser")
 			expect(find_field('Site Editor UNIs').value).to eq("adminPartner, adminUser")			
 		end
+    it 'does not update owner if user does not exist' do
+      original_owner = find_field('Site Owner UNI').value
+      fill_in('Site Owner UNI', with: 'DNE_user')
+			click_button "Update Permissions"
+			# do a find to make sure page loaded
+			find('#site_permissions_remote_ids')
+			visit(edit_link_href)
+      expect(find_field('Site Owner UNI').value).to eq(original_owner )
+    end
 	end
 	describe '#edit' do
 		before do

--- a/spec/features/sites/scope_filters_controller_spec.rb
+++ b/spec/features/sites/scope_filters_controller_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe ::Sites::ScopeFiltersController, type: :feature do
 	include_context "site fixtures for features"
+  let!(:owner) { FactoryBot.create(:user, uid: 'owner_uid') }
 	let(:source) { fixture("sites/import/directory").path }
 	let(:import) { Dcv::Sites::Import::Directory.new(source) }
 	let(:site_slug) { import.atts['slug'] }

--- a/spec/fixtures/sites/import/directory/properties.yml
+++ b/spec/fixtures/sites/import/directory/properties.yml
@@ -2,6 +2,7 @@ slug: import_site
 publisher_uri: info:fedora/cul:import_site
 editor_uids: []
 image_uris: []
+owner_uid: owner_uid
 title: Imported Site
 alternative_title: 'The Site: Imported!'
 repository_id: NNC

--- a/spec/requests/admin/uploads_controller_spec.rb
+++ b/spec/requests/admin/uploads_controller_spec.rb
@@ -8,7 +8,7 @@ describe 'Admin site uploads and imports', type: :request do
   let(:owner) { FactoryBot.create(:user, uid: 'owner_uid') }
   let(:user) { FactoryBot.create(:user) }
   before do
-    FactoryBot.create(:site, slug: 'dlc_site', title: 'Existing DLC Site', editor_uids: ['editor_uid'], owner_uid: 'owner_uid')
+    FactoryBot.create(:site, slug: 'dlc_site', title: 'Existing DLC Site', editor_uids: ['editor_uid'], owner: owner)
   end
 
   describe 'GET admin/import' do

--- a/spec/requests/admin/uploads_controller_spec.rb
+++ b/spec/requests/admin/uploads_controller_spec.rb
@@ -2,9 +2,14 @@
 
 require 'rails_helper'
 
+def create_test_site
+  FactoryBot.create(:site, slug: 'dlc_site', title: 'Existing DLC Site', editor_uids: ['editor_uid'], owner_uid: 'owner_uid')
+end
+
 describe 'Admin site uploads and imports', type: :request do
   let(:admin) { FactoryBot.create(:user, is_admin: true) }
   let(:editor) { FactoryBot.create(:user, uid: 'editor_uid') }
+  let(:owner) { FactoryBot.create(:user, uid: 'owner_uid') }
   let(:user) { FactoryBot.create(:user) }
 
   describe 'GET admin/import' do
@@ -19,7 +24,7 @@ describe 'Admin site uploads and imports', type: :request do
     context 'when authenticated editor' do
       context 'in non-prod environment' do
         it 'returns status OK' do
-          FactoryBot.create(:site, slug: 'dlc_site', title: 'Existing DLC Site', editor_uids: ['editor_uid'])
+          create_test_site()
           sign_in editor
           get '/admin/import'
           expect(response).to have_http_status(:ok)
@@ -28,7 +33,7 @@ describe 'Admin site uploads and imports', type: :request do
       context 'in dlc_prod environment' do
         it 'redirects to sign_in' do
           allow(Rails.env).to receive(:dlc_prod?).and_return(true)
-          FactoryBot.create(:site, slug: 'dlc_site', title: 'Existing DLC Site', editor_uids: ['editor_uid'])
+          create_test_site
           sign_in editor
           get '/admin/import'
           expect(response).to redirect_to('/sign_in?referer=%2Fadmin%2Fimport')
@@ -74,7 +79,7 @@ describe 'Admin site uploads and imports', type: :request do
 
     context 'in dlc_prod environment' do
       before do
-        FactoryBot.create(:site, slug: 'dlc_site', title: 'Existing DLC Site', editor_uids: ['editor_uid'])
+        create_test_site
         allow(Rails.env).to receive(:dlc_prod?).and_return(true)
       end
 

--- a/spec/requests/admin/uploads_controller_spec.rb
+++ b/spec/requests/admin/uploads_controller_spec.rb
@@ -2,29 +2,56 @@
 
 require 'rails_helper'
 
-def create_test_site
-  FactoryBot.create(:site, slug: 'dlc_site', title: 'Existing DLC Site', editor_uids: ['editor_uid'], owner_uid: 'owner_uid')
-end
-
 describe 'Admin site uploads and imports', type: :request do
   let(:admin) { FactoryBot.create(:user, is_admin: true) }
   let(:editor) { FactoryBot.create(:user, uid: 'editor_uid') }
   let(:owner) { FactoryBot.create(:user, uid: 'owner_uid') }
   let(:user) { FactoryBot.create(:user) }
+  before do
+    FactoryBot.create(:site, slug: 'dlc_site', title: 'Existing DLC Site', editor_uids: ['editor_uid'], owner_uid: 'owner_uid')
+  end
 
   describe 'GET admin/import' do
+
     context 'when authenticated admin' do
-      it 'returns status OK' do
-        sign_in admin
-        get '/admin/import'
-        expect(response).to have_http_status(:ok)
+      context 'in non-prod environment' do
+        it 'returns status OK' do
+          sign_in admin
+          get '/admin/import'
+          expect(response).to have_http_status(:ok)
+        end
+      end
+      context 'in prod environment' do
+        it 'returns status OK' do
+          allow(Rails.env).to receive(:dlc_prod?).and_return(true)
+          sign_in admin
+          get '/admin/import'
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+
+    context 'when authenticated owner' do
+      context 'in non-prod environment' do
+        it 'returns status OK' do
+          sign_in owner
+          get '/admin/import'
+          expect(response).to have_http_status(:ok)
+        end
+      end
+      context 'in prod environment' do
+        it 'returns status OK' do
+          allow(Rails.env).to receive(:dlc_prod?).and_return(true)
+          sign_in owner
+          get '/admin/import'
+          expect(response).to have_http_status(:ok)
+        end
       end
     end
 
     context 'when authenticated editor' do
       context 'in non-prod environment' do
         it 'returns status OK' do
-          create_test_site()
           sign_in editor
           get '/admin/import'
           expect(response).to have_http_status(:ok)
@@ -33,7 +60,6 @@ describe 'Admin site uploads and imports', type: :request do
       context 'in dlc_prod environment' do
         it 'redirects to sign_in' do
           allow(Rails.env).to receive(:dlc_prod?).and_return(true)
-          create_test_site
           sign_in editor
           get '/admin/import'
           expect(response).to redirect_to('/sign_in?referer=%2Fadmin%2Fimport')
@@ -63,10 +89,10 @@ describe 'Admin site uploads and imports', type: :request do
     let(:mock_import) { instance_double(SubsiteImportService) }
 
     context 'when authenticated non-privileged user' do
-      it 'redirects to sign_in' do
+      it 'does not authorize upload' do
         sign_in user
         post '/admin/upload'
-        expect(response).to redirect_to('/sign_in?referer=%2Fadmin%2Fupload')
+        expect(flash[:error]).to include('not authorized')
       end
     end
 
@@ -79,34 +105,91 @@ describe 'Admin site uploads and imports', type: :request do
 
     context 'in dlc_prod environment' do
       before do
-        create_test_site
         allow(Rails.env).to receive(:dlc_prod?).and_return(true)
       end
 
       it 'does not authorize dlc site editors' do
         sign_in editor
         post '/admin/upload'
-        expect(response).to redirect_to('/sign_in?referer=%2Fadmin%2Fupload')
+        expect(flash[:error]).to include('not authorized')
       end
     end
 
-    context 'with a valid upload' do
-      before do
-        sign_in admin
-        allow(SubsiteImportService).to receive(:new).and_return(mock_import)
-        allow(mock_import).to receive(:import_subsite).and_return(nil)
-        allow(mock_import).to receive(:finish_message).and_return('test message')
+    # Do not include subsite_slug param
+    context 'with a valid new upload' do
+      context 'as owner user' do 
+        before do
+          sign_in owner
+          allow(SubsiteImportService).to receive(:new).and_return(mock_import)
+          allow(mock_import).to receive(:import_subsite).and_return(nil)
+          allow(mock_import).to receive(:finish_message).and_return('test message')
+          post '/admin/upload', params: { upload: mock_upload }
+        end
 
-        post '/admin/upload', params: { upload: mock_upload }
+        it 'sends unprocessable entity response' do
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        it 'sets the flash error message' do
+          expect(flash[:error]).to include('not authorized')
+        end
       end
 
-      it 'redirects to admin import path' do
-        expect(response).to redirect_to('/admin/import')
+      context 'as admin user' do before do
+          sign_in admin
+          allow(SubsiteImportService).to receive(:new).and_return(mock_import)
+          allow(mock_import).to receive(:import_subsite).and_return(nil)
+          allow(mock_import).to receive(:finish_message).and_return('test message')
+          post '/admin/upload', params: { upload: mock_upload }
+        end
+
+        it 'redirects to admin import path' do
+          expect(response).to redirect_to('/admin/import')
+        end
+
+        it 'sets the flash success message' do
+          expect(flash[:success]).to include('Your upload is complete')
+        end
+      end
+    end
+
+    # include subsite_slug param
+    context 'with a valid reupload' do
+      context 'as owner user' do 
+        before do
+          sign_in owner
+          allow(SubsiteImportService).to receive(:new).and_return(mock_import)
+          allow(mock_import).to receive(:import_subsite).and_return(nil)
+          allow(mock_import).to receive(:finish_message).and_return('test message')
+          post '/admin/upload', params: { upload: mock_upload, slug: 'dlc_site' }
+        end
+
+        it 'redirects to admin import path' do
+          expect(response).to redirect_to('/admin/import')
+        end
+
+        it 'sets the flash success message' do
+          expect(flash[:success]).to include('Your upload is complete')
+        end
       end
 
-      it 'sets the flash success message' do
-        expect(flash[:success]).to include('Your upload is complete')
+      context 'as admin user' do before do
+          sign_in admin
+          allow(SubsiteImportService).to receive(:new).and_return(mock_import)
+          allow(mock_import).to receive(:import_subsite).and_return(nil)
+          allow(mock_import).to receive(:finish_message).and_return('test message')
+          post '/admin/upload', params: { upload: mock_upload, slug: 'dlc_site' }
+        end
+
+        it 'redirects to admin import path' do
+          expect(response).to redirect_to('/admin/import')
+        end
+
+        it 'sets the flash success message' do
+          expect(flash[:success]).to include('Your upload is complete')
+        end
       end
+
     end
 
     context 'with an invalid upload' do


### PR DESCRIPTION
### [Jira Ticket](https://columbiauniversitylibraries.atlassian.net/browse/DLC-1291)
***
This PR adds a new role to the DLC -- subsite owner.

### Description:
A subsite owner is basically a privileged type of editor. It is easiest to explain the changes by describing each role.

Editors:
- can create exports of a subsite they are editor for in any environment
- can perform a subsite import in any environment _besides_ `dlc_prod`
- **change**: can no longer edit the subsite editor list

Owners( everything is new):
- can perform a subsite import to an existing subsite in `dlc_prod` for a subsite they own
- can change the owner of a subsite they own
- can change the editors list of a subsite they own

Admins:
- **unique**: can create a new subsite via the import feature in any environment
- can do all other actions that an Owner and Editor can do

### Implementation:
- the `Site` model now has a `onwer_uid` field that determines the owner. this is a required, nonnull field
  - this value is set by default to 'bal35', which is Brian's uni
    - The default owner value comes from the `dcv.yaml` config file
  - the model is now in a `belongs_to` association with an owner user, and the 'owner_uid' field is required during validation
  - an earlier db migration referenced the Site model class directly (to reference some constants defined on the class), which was breaking migrations in a fresh db (like the test suite, or a freshly cloned instance of dlc) because saving a Site instance violated the validation check for an 'owner_uid' field. The solution was to mock the class for the needed values in that migration.
- I refactored much of the `ability.rb` file to simplify ability checks before I added the new Owner role abilities.
  - some new abilities were added and some existing ones were renamed or split into separate abilities (e.g., ability to view the import view and ability to perform an import of a new subsite)
- Many changes were made to the import/export directory and zip file features, to restrict new uploads to only admins and prod-only uploads to only owners
- Changed the subsite permissions edit page to:
  - created a simple form field for setting a subsite's owner
  - disable editing the owner and editors values to just the owners and admins
- added the 'owner_uid' field as needed to different tests and references to the `Site` model

### N.B.
- This does not include react admin UI changes, mainly because the testing branch has not been merged yet. That branch includes some UI refactoring that would complicate implementing this too early. It also would be best to make sure we have the ability to test this before shipping it, as it pertains to security + authorization.
- **When we deploy**, we will need to add a default owner to the config files on the host machines