### PR TITLE
DLC-1309: adds separate indexing for dlc-group topics

### DIFF
--- a/lib/dcv/solr/document_adapter/mods_xml/fields.rb
+++ b/lib/dcv/solr/document_adapter/mods_xml/fields.rb
@@ -364,7 +364,7 @@ class Dcv::Solr::DocumentAdapter::ModsXml
     def all_subjects(node=mods)
       list_of_subjects = []
 
-      node.xpath("./mods:subject[not(@authority) or @authority != 'Durst']/mods:topic", MODS_NS).collect do |n|
+      node.xpath("./mods:subject[not(@authority) or (@authority != 'Durst' and @authority != 'dlc-group')]/mods:topic", MODS_NS).collect do |n|
         list_of_subjects << Fields.normalize(n.text, true)
       end
       node.xpath("./mods:subject/mods:geographic", MODS_NS).collect do |n|

--- a/lib/dcv/solr/document_adapter/mods_xml/om_rules.rb
+++ b/lib/dcv/solr/document_adapter/mods_xml/om_rules.rb
@@ -102,19 +102,19 @@ class Dcv::Solr::DocumentAdapter::ModsXml
       solr_doc['table_of_contents_ssm'] = table_of_contents_text
       solr_doc['all_text_teim'].concat textable(table_of_contents_text)
 
-      #t.subject(:index_as=>[:textable]){
       mods.xpath("./mods:subject", MODS_NS).each do |subject|
-        solr_doc['all_text_teim'].concat(textable(subject.text))
-      #  t.topic(:index_as=>[:facetable, :displayable])
-        topic_text = subject.xpath("mods:topic", MODS_NS).map(&:text)
-        if topic_text.present?
-          if subject['authority'] == 'dlc-group'
-            uri = subject.xpath("mods:topic", MODS_NS).first&.[]('valueURI')
-            solr_doc['dlc_group_uri_ssim'] ||= []
-            solr_doc['dlc_group_uri_ssim'] << uri if uri
-          else
-            solr_doc['subject_topic_sim'] = topic_text
-            solr_doc['subject_topic_ssm'] = topic_text
+        if subject['authority'] == 'dlc-group'
+          uris = subject.xpath("mods:topic", MODS_NS).map { |t| t['valueURI'] }.compact
+          solr_doc['dlc_group_uri_ssim'] ||= []
+          solr_doc['dlc_group_uri_ssim'].concat(uris)
+        else
+          #t.subject(:index_as=>[:textable]){ except dlc-group
+          solr_doc['all_text_teim'].concat(textable(subject.text))
+          #  t.topic(:index_as=>[:facetable, :displayable])
+          topic_text = subject.xpath("mods:topic", MODS_NS).map(&:text)
+          if topic_text.present?
+              solr_doc['subject_topic_sim'] = topic_text
+              solr_doc['subject_topic_ssm'] = topic_text
           end
         end
       #  t.geographic(:index_as=>[:facetable])

--- a/lib/dcv/solr/document_adapter/mods_xml/om_rules.rb
+++ b/lib/dcv/solr/document_adapter/mods_xml/om_rules.rb
@@ -108,8 +108,14 @@ class Dcv::Solr::DocumentAdapter::ModsXml
       #  t.topic(:index_as=>[:facetable, :displayable])
         topic_text = subject.xpath("mods:topic", MODS_NS).map(&:text)
         if topic_text.present?
-          solr_doc['subject_topic_sim'] = topic_text
-          solr_doc['subject_topic_ssm'] = topic_text
+          if subject['authority'] == 'dlc-group'
+            uri = subject.xpath("mods:topic", MODS_NS).first&.[]('valueURI')
+            solr_doc['dlc_group_uri_ssim'] ||= []
+            solr_doc['dlc_group_uri_ssim'] << uri if uri
+          else
+            solr_doc['subject_topic_sim'] = topic_text
+            solr_doc['subject_topic_ssm'] = topic_text
+          end
         end
       #  t.geographic(:index_as=>[:facetable])
         geographic_text = subject.xpath("mods:geographic", MODS_NS).map(&:text)

--- a/spec/fixtures/mods/mods-subjects.xml
+++ b/spec/fixtures/mods/mods-subjects.xml
@@ -82,4 +82,7 @@
       <area>The good part of town</citySection>
     </hierarchicalGeographic>
   </subject>
+  <subject authority="dlc-group">
+    <topic valueURI="http://id.library.columbia.edu/term/473d7b81-057a-457a-b342-7dc05ae83387">DLC Group Topic</topic>
+  </subject> 
 </mods>

--- a/spec/fixtures/mods/mods-subjects.xml
+++ b/spec/fixtures/mods/mods-subjects.xml
@@ -84,5 +84,11 @@
   </subject>
   <subject authority="dlc-group">
     <topic valueURI="http://id.library.columbia.edu/term/473d7b81-057a-457a-b342-7dc05ae83387">DLC Group Topic</topic>
-  </subject> 
+  </subject>
+  <subject authority="dlc-group">
+  <topic valueURI="http://id.library.columbia.edu/term/99999999-0000-0000-0000-000000000001">DLC Group Topic 2</topic>
+  </subject>
+  <subject authority="dlc-group">
+    <topic valueURI="http://id.library.columbia.edu/term/00000000-0000-0000-0000-000000000002"></topic>
+  </subject>
 </mods>

--- a/spec/unit/dcv/solr/document_adapter/mods_xml/om_rules_spec.rb
+++ b/spec/unit/dcv/solr/document_adapter/mods_xml/om_rules_spec.rb
@@ -508,12 +508,24 @@ describe Dcv::Solr::DocumentAdapter::ModsXml, type: :unit do
         expect(subject["subject_topic_ssm"]).not_to include("DLC Group Topic")
       end
 
-      it 'should index valueURIs of topic subjects with authority="dlc-group" into dlc_group_uri_ssim' do
-        expect(subject["dlc_group_uri_ssim"]).to include("http://id.library.columbia.edu/term/473d7b81-057a-457a-b342-7dc05ae83387")
-      end
-
       it 'should not include the topic text in dlc_group_uri_ssim (only URIs, not labels)' do
         expect(subject["dlc_group_uri_ssim"]).not_to include("DLC Group Topic")
+      end
+
+      it 'should index multiple valueURIs from multiple dlc-group subjects into dlc_group_uri_ssim' do
+        expect(subject["dlc_group_uri_ssim"]).to include("http://id.library.columbia.edu/term/473d7b81-057a-457a-b342-7dc05ae83387")
+        expect(subject["dlc_group_uri_ssim"]).to include("http://id.library.columbia.edu/term/99999999-0000-0000-0000-000000000001")
+        expect(subject["dlc_group_uri_ssim"]).to include("http://id.library.columbia.edu/term/00000000-0000-0000-0000-000000000002")
+        expect(subject["dlc_group_uri_ssim"].length).to eql 3
+      end
+
+      it 'should populate dlc_group_uri_ssim even when the dlc-group topic has no text content' do
+        expect(subject["dlc_group_uri_ssim"]).to include("http://id.library.columbia.edu/term/00000000-0000-0000-0000-000000000002")
+      end
+
+      it 'should not include dlc-group subject text in all_text_teim' do
+        expect(all_text_joined).not_to include("DLC Group Topic")
+        expect(all_text_joined).not_to include("DLC Group Topic 2")
       end
     end
 

--- a/spec/unit/dcv/solr/document_adapter/mods_xml/om_rules_spec.rb
+++ b/spec/unit/dcv/solr/document_adapter/mods_xml/om_rules_spec.rb
@@ -469,6 +469,10 @@ describe Dcv::Solr::DocumentAdapter::ModsXml, type: :unit do
         expect(subject["lib_all_subjects_ssm"]).not_to include(ignored_subject)
         expect(subject["lib_all_subjects_teim"]).not_to include(ignored_subject)
       end
+      it 'should NOT include topic subjects with authority="dlc-group" in lib_all_subjects_ssm or lib_all_subjects_teim' do
+        expect(subject["lib_all_subjects_ssm"]).not_to include("DLC Group Topic")
+        expect(subject["lib_all_subjects_teim"]).not_to include("DLC Group Topic")
+      end
       it 'should be pulling in topic subjects with authority="Durst" into durst_subjects_ssim' do
         durst_subject = 'Durst subject that should be ignored'
         expect(subject["durst_subjects_ssim"]).to include(durst_subject)
@@ -495,7 +499,24 @@ describe Dcv::Solr::DocumentAdapter::ModsXml, type: :unit do
           }
         }
       end
+
+      it 'should NOT include topic subjects with authority="dlc-group" in subject_topic_sim' do
+        expect(subject["subject_topic_sim"]).not_to include("DLC Group Topic")
+      end
+
+      it 'should NOT include topic subjects with authority="dlc-group" in subject_topic_ssm' do
+        expect(subject["subject_topic_ssm"]).not_to include("DLC Group Topic")
+      end
+
+      it 'should index valueURIs of topic subjects with authority="dlc-group" into dlc_group_uri_ssim' do
+        expect(subject["dlc_group_uri_ssim"]).to include("http://id.library.columbia.edu/term/473d7b81-057a-457a-b342-7dc05ae83387")
+      end
+
+      it 'should not include the topic text in dlc_group_uri_ssim (only URIs, not labels)' do
+        expect(subject["dlc_group_uri_ssim"]).not_to include("DLC Group Topic")
+      end
     end
+
     context "has classification other cataloged" do
       let(:xml_src) { fixture( File.join("mods", "mods-all.xml") ) }
       it "should only extract classifications with type='z' (other)" do


### PR DESCRIPTION
[DLC-1309](https://columbiauniversitylibraries.atlassian.net/browse/DLC-1309)

I made two assumptions for this. 1) That we are only interested in dlc-group topics that have a topic text value. Right now, if the dlc-group node has a valueURI but no topic text, it is skipped. 2) I'm assuming that there is only ever one valueURI.

If either of these assumptions are wrong, please let me know. Thanks.